### PR TITLE
STR-1448: Add sequencer url for checking its online status

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -40,15 +40,15 @@ impl NetworkConfig {
 
         let rpc_url = std::env::var("RPC_URL")
             .ok()
-            .unwrap_or_else(|| "http://localhost:8432".to_string());
+            .unwrap_or_else(|| "http://localhost:8433".to_string());
 
         let bundler_url = std::env::var("BUNDLER_URL")
             .ok()
-            .unwrap_or_else(|| "http://localhost:8433".to_string());
+            .unwrap_or_else(|| "http://localhost:8434".to_string());
 
         let reth_url = std::env::var("RETH_URL")
             .ok()
-            .unwrap_or_else(|| "http://localhost:8434".to_string());
+            .unwrap_or_else(|| "http://localhost:8435".to_string());
 
         let max_retries: u64 = std::env::var("MAX_STATUS_RETRIES")
             .ok()

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -5,6 +5,9 @@ use crate::activity::ActivityStatsKeys;
 
 #[derive(Debug, Clone)]
 pub(crate) struct NetworkConfig {
+    /// JSON-RPC Endpoint for Alpen batch producer
+    batch_producer_url: String,
+
     /// JSON-RPC Endpoint for Alpen client
     rpc_url: String,
 
@@ -30,6 +33,10 @@ pub(crate) struct NetworkConfig {
 impl NetworkConfig {
     pub fn new() -> Self {
         dotenv().ok(); // Load `.env` file if present
+
+        let batch_producer_url = std::env::var("BATCH_PRODUCER_URL")
+            .ok()
+            .unwrap_or_else(|| "http://localhost:8432".to_string());
 
         let rpc_url = std::env::var("RPC_URL")
             .ok()
@@ -64,6 +71,7 @@ impl NetworkConfig {
         info!(%rpc_url, bundler_url, "Loaded Config");
 
         NetworkConfig {
+            batch_producer_url,
             rpc_url,
             bundler_url,
             reth_url,
@@ -72,6 +80,11 @@ impl NetworkConfig {
             deposit_wallet,
             validating_wallet,
         }
+    }
+
+    /// Getter for `batch_producer_url`
+    pub fn batch_producer_url(&self) -> &str {
+        &self.batch_producer_url
     }
 
     /// Getter for `rpc_url`

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -100,6 +100,7 @@ async fn check_bundler_health(client: &reqwest::Client, config: &NetworkConfig) 
 async fn fetch_statuses_task(state: SharedNetworkState, config: &NetworkConfig) {
     info!("Fetching statuses...");
     let mut interval = interval(Duration::from_secs(10));
+    let batch_producer_client = create_rpc_client(config.batch_producer_url());
     let rpc_client = create_rpc_client(config.rpc_url());
     let http_client = reqwest::Client::new();
     let retry_policy =
@@ -108,7 +109,7 @@ async fn fetch_statuses_task(state: SharedNetworkState, config: &NetworkConfig) 
     loop {
         interval.tick().await;
 
-        let batch_producer = call_rpc_status(config, &rpc_client, retry_policy).await;
+        let batch_producer = call_rpc_status(config, &batch_producer_client, retry_policy).await;
         let rpc_endpoint = call_rpc_status(config, &rpc_client, retry_policy).await;
         let bundler_endpoint = check_bundler_health(&http_client, config).await;
 

--- a/frontend/src/pages/Bridge.tsx
+++ b/frontend/src/pages/Bridge.tsx
@@ -92,7 +92,7 @@ export default function Bridge() {
                                     <span className="bridge-title">
                                         BRIDGE DEPOSIT STATUS
                                     </span>
-                                    {data && data.deposits ? (
+                                    {data && data.deposits.length > 0 ? (
                                         <div className="table-wrapper">
                                             <table className="transactions-table">
                                                 <thead>
@@ -145,7 +145,7 @@ export default function Bridge() {
                                     <span className="bridge-title">
                                         BRIDGE WITHDRAWAL STATUS
                                     </span>
-                                    {data && data.withdrawals ? (
+                                    {data && data.withdrawals.length > 0 ? (
                                         <div className="table-wrapper">
                                             <table className="transactions-table">
                                                 <thead>
@@ -201,7 +201,7 @@ export default function Bridge() {
                                     <span className="bridge-title">
                                         BRIDGE REIMBURSEMENT STATUS
                                     </span>
-                                    {data && data.reimbursements ? (
+                                    {data && data.reimbursements.length > 0 ? (
                                         <div className="table-wrapper">
                                             <table className="transactions-table">
                                                 <thead>


### PR DESCRIPTION
Query sequencer for batch producer status.
Also fixes two small things:
1. Avoid duplicate entries in bridge deposits and withdrawals.
2. Handle empty deposits, withdrawals and reimbursements on the frontend.

Deployed to staging to test. It seems there is no ingress resource with `https://strataseq.temp6-testnet1-staging.stratabtc.org`.

[STR-1448](https://alpenlabs.atlassian.net/browse/STR-1448)

[STR-1448]: https://alpenlabs.atlassian.net/browse/STR-1448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ