### PR TITLE
Filter bridge monitoring entries based on number of confirmations

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -5,10 +5,10 @@ use crate::activity::ActivityStatsKeys;
 
 #[derive(Debug, Clone)]
 pub(crate) struct NetworkConfig {
-    /// JSON-RPC Endpoint for Alpen batch producer
-    batch_producer_url: String,
+    /// JSON-RPC Endpoint for strata sequencer
+    sequencer_url: String,
 
-    /// JSON-RPC Endpoint for Alpen client
+    /// JSON-RPC Endpoint for strata client
     rpc_url: String,
 
     /// JSON-RPC Endpoint for Alpen evm for wallet balance
@@ -34,11 +34,11 @@ impl NetworkConfig {
     pub fn new() -> Self {
         dotenv().ok(); // Load `.env` file if present
 
-        let batch_producer_url = std::env::var("BATCH_PRODUCER_URL")
+        let sequencer_url = std::env::var("STRATA_SEQUENCER_URL")
             .ok()
             .unwrap_or_else(|| "http://localhost:8432".to_string());
 
-        let rpc_url = std::env::var("ALPEN_RPC_URL")
+        let rpc_url = std::env::var("STRATA_RPC_URL")
             .ok()
             .unwrap_or_else(|| "http://localhost:8433".to_string());
 
@@ -71,7 +71,7 @@ impl NetworkConfig {
         info!(%rpc_url, bundler_url, "Loaded Network monitoring config:");
 
         NetworkConfig {
-            batch_producer_url,
+            sequencer_url,
             rpc_url,
             bundler_url,
             reth_url,
@@ -82,9 +82,9 @@ impl NetworkConfig {
         }
     }
 
-    /// Getter for `batch_producer_url`
-    pub fn batch_producer_url(&self) -> &str {
-        &self.batch_producer_url
+    /// Getter for `sequencer_url`
+    pub fn sequencer_url(&self) -> &str {
+        &self.sequencer_url
     }
 
     /// Getter for `rpc_url`
@@ -202,11 +202,17 @@ impl ActivityMonitoringConfig {
 
 /// Default bridge status refetch interval in seconds
 const DEFAULT_BRIDGE_STATUS_REFETCH_INTERVAL_S: u64 = 120;
+/// Default maximum number of confirmations for transactions tracked
+const DEFAULT_MAX_TX_CONFIRMATIONS: u64 = 6;
 
 /// Bridge monitoring configuration
 pub struct BridgeMonitoringConfig {
     /// Alpen bridge RPC url
     bridge_rpc_url: String,
+    /// Esplora URL
+    esplora_url: String,
+    /// Maximum confirmations
+    max_tx_confirmations: u64,
     /// Bridge status refetch interval in seconds
     status_refetch_interval_s: u64,
 }
@@ -219,15 +225,26 @@ impl BridgeMonitoringConfig {
             .ok()
             .unwrap_or_else(|| "http://localhost:8546".to_string());
 
+        let esplora_url = std::env::var("ESPLORA_URL")
+            .ok()
+            .unwrap_or_else(|| "http://localhost:8547".to_string());
+
+        let max_tx_confirmations: u64 = std::env::var("BRIDGE_TX_MAX_CONFIRMATIONS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_MAX_TX_CONFIRMATIONS);
+
         let refresh_interval_s: u64 = std::env::var("BRIDGE_STATUS_REFETCH_INTERVAL_S")
             .ok()
             .and_then(|s| s.parse::<u64>().ok())
             .unwrap_or(DEFAULT_BRIDGE_STATUS_REFETCH_INTERVAL_S);
 
-        info!(%bridge_rpc_url, "Loaded Bridge monitoring config:");
+        info!(%bridge_rpc_url, %esplora_url, "Loaded Bridge monitoring config:");
 
         BridgeMonitoringConfig {
             bridge_rpc_url,
+            esplora_url,
+            max_tx_confirmations,
             status_refetch_interval_s: refresh_interval_s,
         }
     }
@@ -235,6 +252,16 @@ impl BridgeMonitoringConfig {
     /// Getter for `bridge_rpc_url`
     pub fn bridge_rpc_url(&self) -> &str {
         &self.bridge_rpc_url
+    }
+
+    /// Getter for `esplora_url`
+    pub fn esplora_url(&self) -> &str {
+        &self.esplora_url
+    }
+
+    /// Getter for `max_tx_confirmations`
+    pub fn max_tx_confirmations(&self) -> u64 {
+        self.max_tx_confirmations
     }
 
     /// Getter for `status_refetch_interval_s`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,11 @@ services:
       dockerfile: backend.Dockerfile
     container_name: alpen_dashboards_backend
     environment:
-      ALPEN_RPC_URL: https://rpc.testnet.alpenlabs.io
+      STRATA_SEQUENCER_URL: https://strataseq.testnet.alpenlabs.io
+      STRATA_RPC_URL: https://rpc.testnet.alpenlabs.io
       ALPEN_BRIDGE_RPC_URL: https://bridge.testnet.alpenlabs.io/1
+      ESPLORA_URL: https://esplora.testnet.alpenlabs.io
+      BRIDGE_TX_MAX_CONFIRMATIONS: 6
       BUNDLER_URL: https://bundler.testnet.alpenlabs.io/health
       USER_OPS_QUERY_URL: https://explorer.testnet.alpenlabs.io/api/v2/proxy/account-abstraction/operations
       ACCOUNTS_QUERY_URL: https://explorer.testnet.alpenlabs.io/api/v2/proxy/account-abstraction/accounts

--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -1,7 +1,7 @@
 {
     "apiBaseUrl": "http://localhost:3000",
-    "bitcoinExplorerUrl": "https://bitcoin.testnet.alpenlabs.io",
-    "alpenExplorerUrl": "https://explorer.testnet.alpenlabs.io",
+    "bitcoinExplorerUrl": "https://bitcoin.testnet-staging.stratabtc.org",
+    "alpenExplorerUrl": "https://explorer.testnet-staging.stratabtc.org",
     "networkStatusRefetchIntervalS": 60,
     "bridgeStatusRefetchIntervalS": 120,
     "activityStatsRefetchIntervalS": 60,

--- a/frontend/src/hooks/useNetworkStatus.ts
+++ b/frontend/src/hooks/useNetworkStatus.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useConfig } from "./useConfig";
 
 export type NetworkStatus = {
-    batch_producer: string;
+    sequencer: string;
     rpc_endpoint: string;
     bundler_endpoint: string;
 };

--- a/frontend/src/pages/Bridge.tsx
+++ b/frontend/src/pages/Bridge.tsx
@@ -272,7 +272,7 @@ export default function Bridge() {
                                         </div>
                                     ) : (
                                         <p className="no-items">
-                                            No bridge withdrawals found.
+                                            No bridge reimbursements found.
                                         </p>
                                     )}
                                 </div>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -94,9 +94,9 @@ export default function Dashboard() {
                             ) : (
                                 <div className="status-cards">
                                     <StatusCard
-                                        title="Batch producer status"
+                                        title="Sequencer status"
                                         status={
-                                            data?.batch_producer.toUpperCase() ??
+                                            data?.sequencer.toUpperCase() ??
                                             "Unknown"
                                         }
                                     />


### PR DESCRIPTION
1. Rename batch producer to sequencer
2. Filter deposits, withdrawals and reimbursements based on PRD requirement: fewer than 6 confirmations for `Complete`, `Cancelled` or `Failed`.