### PR TITLE
handle parse error for chain tip height

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -112,10 +112,10 @@ jobs:
 
 
           echo "Updating frontend tag in $VALUES_FILE"
-          yq eval -i ".strataDashboard.frontend.image.tag = \"$SHORT_TAG\"" "$VALUES_FILE"
+          yq eval -i ".strataStatus.frontend.image.tag = \"$SHORT_TAG\"" "$VALUES_FILE"
 
           echo "Updating backend tag in $VALUES_FILE"
-          yq eval -i ".strataDashboard.backend.image.tag = \"$SHORT_TAG\"" "$VALUES_FILE"
+          yq eval -i ".strataStatus.backend.image.tag = \"$SHORT_TAG\"" "$VALUES_FILE"
 
 
       - name: Commit and push changes

--- a/backend/src/bridge.rs
+++ b/backend/src/bridge.rs
@@ -53,7 +53,7 @@ pub(crate) enum DepositStatus {
     Complete,
 }
 
-/// Deposit information passed to dashboard
+/// Deposit information passed to status dashboard
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub(crate) struct DepositInfo {
     pub deposit_request_txid: Txid,
@@ -91,7 +91,7 @@ pub(crate) enum WithdrawalStatus {
     Complete,
 }
 
-/// Withdrawal information passed to dashboard
+/// Withdrawal information passed to status dashboard
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub(crate) struct WithdrawalInfo {
     pub withdrawal_request_txid: Buf32,
@@ -126,7 +126,7 @@ pub enum ReimbursementStatus {
     Complete,
 }
 
-/// Claim and reimbursement information passed to dashboard
+/// Claim and reimbursement information passed to status dashboard
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub(crate) struct ReimbursementInfo {
     pub claim_txid: Txid,
@@ -249,16 +249,14 @@ async fn get_operator_status(rpc_url: &str) -> RpcOperatorStatus {
 }
 
 /// Fetch bitcoin chain tip height
-async fn get_bitcoin_chain_tip_height(esplora_url: &str) -> Result<u64, reqwest::Error> {
+async fn get_bitcoin_chain_tip_height(
+    esplora_url: &str,
+) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
     let endpoint = format!("{}/blocks/tip/height", esplora_url.trim_end_matches('/'));
-    let resp = reqwest::Client::new()
-        .get(&endpoint)
-        .send()
-        .await?
-        .text()
-        .await?;
+    let resp = reqwest::Client::new().get(&endpoint).send().await?;
 
-    let height = resp.trim().parse::<u64>().expect("valid height");
+    let text = resp.text().await?;
+    let height = text.trim().parse::<u64>()?;
     Ok(height)
 }
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,9 +8,9 @@ export default defineConfig({
     },
     server: {
         allowedHosts: [
-            "dashboard.testnet.alpenlabs.io",
-            "dashboard.testnet-staging.stratabtc.org",
-            "dashboard.development.stratabtc.org",
+            "status.testnet.alpenlabs.io",
+            "status.testnet-staging.stratabtc.org",
+            "status.development.stratabtc.org",
         ],
     },
 });


### PR DESCRIPTION
Catch parse error for chain tip height so bridge monitoring does not crash on error.
Also some "dashboard" to "status" changes.