### PR TITLE
fix (bridge): make order of operators fixed

### DIFF
--- a/backend/src/bridge/status.rs
+++ b/backend/src/bridge/status.rs
@@ -156,15 +156,13 @@ pub async fn bridge_monitoring_task(context: Arc<BridgeMonitoringContext>) {
 
         // Bridge operator status
         let mut operator_statuses = Vec::new();
-        for (index, public_key_string) in context.config.bridge_rpc_urls().keys().enumerate() {
+        let mut sorted_operators: Vec<_> = context.config.bridge_rpc_urls().iter().collect();
+        sorted_operators.sort_by_key(|(_, rpc_url)| *rpc_url);
+
+        for (index, (public_key_string, rpc_url)) in sorted_operators.iter().enumerate() {
             let operator_id = format!("Alpen Labs #{}", index + 1);
             let pk_bytes = hex::decode(public_key_string).expect("decode to succeed");
             let operator_pk = PublicKey::from_slice(&pk_bytes).expect("conversion to succeed");
-            let rpc_url = context
-                .config
-                .bridge_rpc_urls()
-                .get(public_key_string)
-                .expect("valid rpc url");
             let status = get_operator_status(rpc_url).await;
 
             operator_statuses.push(OperatorStatus::new(operator_id, operator_pk, status));


### PR DESCRIPTION
## Description

This fix is to make sure we see the same order of bridge operators in bridge monitoring page. The list is now sorted by rpc url. This makes sense based on how we set the rpc url.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 