### PR TITLE
refactor: encapsulate monitoring context state

### DIFF
--- a/backend/crates/bridge/src/context.rs
+++ b/backend/crates/bridge/src/context.rs
@@ -1,0 +1,132 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tokio::sync::{Notify, RwLock};
+use tracing::debug;
+
+use super::{cache::BridgeStatusCache, types::BridgeStatus};
+use status_config::BridgeMonitoringConfig;
+
+/// Bridge monitoring task context.
+pub struct BridgeMonitoringContext {
+    config: BridgeMonitoringConfig,
+    state: RwLock<BridgeStatusCache>,
+    status_available: AtomicBool,
+    initial_status_query_complete: Notify,
+}
+
+impl BridgeMonitoringContext {
+    pub fn new(config: BridgeMonitoringConfig) -> Self {
+        Self {
+            config,
+            state: RwLock::new(BridgeStatusCache::default()),
+            status_available: AtomicBool::new(false),
+            initial_status_query_complete: Notify::new(),
+        }
+    }
+
+    pub(crate) fn config(&self) -> &BridgeMonitoringConfig {
+        &self.config
+    }
+
+    pub(crate) async fn with_state<T>(&self, f: impl FnOnce(&BridgeStatusCache) -> T) -> T {
+        let state = self.state.read().await;
+        f(&state)
+    }
+
+    pub(crate) async fn with_state_mut<T>(&self, f: impl FnOnce(&mut BridgeStatusCache) -> T) -> T {
+        let mut state = self.state.write().await;
+        f(&mut state)
+    }
+
+    pub(crate) fn mark_status_available(&self) {
+        if self
+            .status_available
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            self.initial_status_query_complete.notify_waiters();
+        }
+    }
+
+    pub(crate) async fn wait_until_status_available(&self) {
+        if !self.status_available.load(Ordering::Acquire) {
+            debug!("Waiting for initial bridge status query to complete");
+            self.initial_status_query_complete.notified().await;
+        }
+    }
+
+    pub(crate) async fn bridge_status(&self) -> BridgeStatus {
+        let cache = self.state.read().await;
+
+        BridgeStatus {
+            operators: cache.get_operators(),
+            deposits: cache
+                .filter_deposits(|_| true)
+                .into_iter()
+                .map(|(_, info)| info)
+                .collect(),
+            withdrawals: cache
+                .filter_withdrawals(|_| true)
+                .into_iter()
+                .map(|(_, info)| info)
+                .collect(),
+            reimbursements: cache
+                .filter_reimbursements(|_| true)
+                .into_iter()
+                .map(|(_, info)| info)
+                .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::Txid;
+    use std::str::FromStr;
+
+    use super::*;
+    use crate::types::{DepositInfo, DepositStatus};
+
+    #[tokio::test]
+    async fn bridge_status_reflects_cached_state() {
+        let config: BridgeMonitoringConfig = toml::from_str(
+            r#"
+            esplora_url = "http://localhost:3000"
+            max_tx_confirmations = 6
+            status_refetch_interval_s = 1
+            operators = []
+            "#,
+        )
+        .expect("test config should deserialize");
+        let context = BridgeMonitoringContext::new(config);
+        let deposit_request_txid =
+            Txid::from_str("0101010101010101010101010101010101010101010101010101010101010101")
+                .expect("valid txid");
+        let deposit_txid =
+            Txid::from_str("0202020202020202020202020202020202020202020202020202020202020202")
+                .expect("valid txid");
+
+        context
+            .with_state_mut(|state| {
+                state.update_deposit(
+                    deposit_request_txid,
+                    DepositInfo {
+                        deposit_request_txid,
+                        deposit_txid: Some(deposit_txid),
+                        status: DepositStatus::Complete,
+                    },
+                    1,
+                );
+            })
+            .await;
+
+        let status = context.bridge_status().await;
+
+        assert_eq!(status.deposits.len(), 1);
+        assert_eq!(
+            status.deposits[0].deposit_request_txid,
+            deposit_request_txid
+        );
+        assert_eq!(status.deposits[0].deposit_txid, Some(deposit_txid));
+    }
+}

--- a/backend/crates/bridge/src/lib.rs
+++ b/backend/crates/bridge/src/lib.rs
@@ -1,9 +1,11 @@
 mod cache;
+mod context;
 mod db;
 mod status;
 mod types;
 mod withdrawal_indexer;
 
+pub use context::BridgeMonitoringContext;
 pub use status::{bridge_monitoring_task, get_bridge_status};
-pub use types::{BridgeMonitoringContext, BridgeStatus};
+pub use types::BridgeStatus;
 pub use withdrawal_indexer::task::run_withdrawal_indexer;

--- a/backend/crates/bridge/src/status.rs
+++ b/backend/crates/bridge/src/status.rs
@@ -4,7 +4,7 @@ use bitcoin::{secp256k1::PublicKey, Txid};
 
 use jsonrpsee::http_client::HttpClient;
 use std::collections::BTreeMap;
-use std::sync::{atomic::Ordering, Arc};
+use std::sync::Arc;
 use strata_bridge_rpc::traits::{StrataBridgeControlApiClient, StrataBridgeMonitoringApiClient};
 use strata_bridge_rpc::types::{
     RpcDepositStatus, RpcOperatorStatus, RpcReimbursementStatus, RpcWithdrawalStatus,
@@ -14,10 +14,10 @@ use strata_primitives::buf::Buf32;
 use strata_tasks::ShutdownGuard;
 
 use super::{
-    cache::BridgeStatusCache,
+    context::BridgeMonitoringContext,
     types::{
-        BridgeMonitoringContext, BridgeStatus, DepositInfo, DepositStatus, OperatorStatus,
-        ReimbursementInfo, ReimbursementStatus, TxStatus, WithdrawalInfo, WithdrawalStatus,
+        BridgeStatus, DepositInfo, DepositStatus, OperatorStatus, ReimbursementInfo,
+        ReimbursementStatus, TxStatus, WithdrawalInfo, WithdrawalStatus,
     },
 };
 
@@ -185,15 +185,12 @@ async fn get_tx_confirmations(esplora_url: &str, txid: Txid, chain_tip_height: u
 
 /// Determine which cached deposit entries should be purged
 async fn determine_deposits_to_purge(
-    cache: &BridgeStatusCache,
+    final_deposits: Vec<(Txid, DepositInfo)>,
     config: &BridgeMonitoringConfig,
     chain_tip_height: u64,
 ) -> Vec<Txid> {
     let max_confirmations = config.max_tx_confirmations();
     let mut deposits_to_purge = Vec::new();
-
-    let final_deposits =
-        cache.filter_deposits(|s| matches!(s, DepositStatus::Complete | DepositStatus::Failed));
 
     for (txid, deposit_info) in final_deposits {
         let check_txid = match deposit_info.status {
@@ -219,14 +216,12 @@ async fn determine_deposits_to_purge(
 
 /// Determine which cached withdrawal entries should be purged
 async fn determine_withdrawals_to_purge(
-    cache: &BridgeStatusCache,
+    final_withdrawals: Vec<(Buf32, WithdrawalInfo)>,
     config: &BridgeMonitoringConfig,
     chain_tip_height: u64,
 ) -> Vec<Buf32> {
     let max_confirmations = config.max_tx_confirmations();
     let mut withdrawals_to_purge = Vec::new();
-
-    let final_withdrawals = cache.filter_withdrawals(|s| matches!(s, WithdrawalStatus::Complete));
 
     for (request_id, withdrawal_info) in final_withdrawals {
         if let Some(fulfillment_txid) = withdrawal_info.fulfillment_txid {
@@ -247,19 +242,12 @@ async fn determine_withdrawals_to_purge(
 
 /// Determine which cached reimbursement entries should be purged
 async fn determine_reimbursements_to_purge(
-    cache: &BridgeStatusCache,
+    final_reimbursements: Vec<(Txid, ReimbursementInfo)>,
     config: &BridgeMonitoringConfig,
     chain_tip_height: u64,
 ) -> Vec<Txid> {
     let max_confirmations = config.max_tx_confirmations();
     let mut reimbursements_to_purge = Vec::new();
-
-    let final_reimbursements = cache.filter_reimbursements(|s| {
-        matches!(
-            s,
-            ReimbursementStatus::Complete | ReimbursementStatus::Cancelled
-        )
-    });
 
     for (txid, reimbursement_info) in final_reimbursements {
         let check_txid = match reimbursement_info.status {
@@ -291,11 +279,11 @@ pub async fn bridge_monitoring_task(
     shutdown: ShutdownGuard,
 ) -> Result<()> {
     let mut interval = interval(Duration::from_secs(
-        context.config.status_refetch_interval(),
+        context.config().status_refetch_interval(),
     ));
 
     // Create RPC client manager once and reuse it
-    let rpc_manager = RpcClientManager::new(&context.config);
+    let rpc_manager = RpcClientManager::new(context.config());
 
     loop {
         tokio::select! {
@@ -308,7 +296,7 @@ pub async fn bridge_monitoring_task(
         // Bridge operator status
         let mut operator_statuses = Vec::new();
 
-        for (index, operator) in context.config.operators().iter().enumerate() {
+        for (index, operator) in context.config().operators().iter().enumerate() {
             let operator_id = format!("Alpen Labs #{}", index + 1);
             let pk_bytes = hex::decode(operator.public_key()).expect("decode to succeed");
             let operator_pk = PublicKey::from_slice(&pk_bytes).expect("conversion to succeed");
@@ -317,13 +305,14 @@ pub async fn bridge_monitoring_task(
         }
 
         // Update operators incrementally
-        {
-            let mut cache = context.status_cache.write().await;
-            cache.update_operators(operator_statuses);
-        }
+        context
+            .with_state_mut(|cache| {
+                cache.update_operators(operator_statuses);
+            })
+            .await;
 
         let chain_tip_height =
-            match get_bitcoin_chain_tip_height(context.config.esplora_url()).await {
+            match get_bitcoin_chain_tip_height(context.config().esplora_url()).await {
                 Ok(height) => height,
                 Err(e) => {
                     error!(error = %e, "failed to get Bitcoin chain tip");
@@ -333,35 +322,36 @@ pub async fn bridge_monitoring_task(
         info!(%chain_tip_height, "bitcoin chain tip");
 
         // Get existing active entries from cache to avoid unnecessary RPC calls
-        let (active_deposits, active_withdrawals, active_reimbursements) = {
-            let cache = context.status_cache.read().await;
-            let deposits: Vec<Txid> = cache
-                .filter_deposits(|s| matches!(s, DepositStatus::InProgress))
-                .iter()
-                .map(|(txid, _)| *txid)
-                .collect();
-            let withdrawals: Vec<Buf32> = cache
-                .filter_withdrawals(|s| matches!(s, WithdrawalStatus::InProgress))
-                .iter()
-                .map(|(request_id, _)| *request_id)
-                .collect();
-            let reimbursements: Vec<Txid> = cache
-                .filter_reimbursements(|s| {
-                    matches!(
-                        s,
-                        ReimbursementStatus::InProgress | ReimbursementStatus::Challenged
-                    )
-                })
-                .iter()
-                .map(|(txid, _)| *txid)
-                .collect();
-            (deposits, withdrawals, reimbursements)
-        };
+        let (active_deposits, active_withdrawals, active_reimbursements) = context
+            .with_state(|cache| {
+                let deposits: Vec<Txid> = cache
+                    .filter_deposits(|s| matches!(s, DepositStatus::InProgress))
+                    .iter()
+                    .map(|(txid, _)| *txid)
+                    .collect();
+                let withdrawals: Vec<Buf32> = cache
+                    .filter_withdrawals(|s| matches!(s, WithdrawalStatus::InProgress))
+                    .iter()
+                    .map(|(request_id, _)| *request_id)
+                    .collect();
+                let reimbursements: Vec<Txid> = cache
+                    .filter_reimbursements(|s| {
+                        matches!(
+                            s,
+                            ReimbursementStatus::InProgress | ReimbursementStatus::Challenged
+                        )
+                    })
+                    .iter()
+                    .map(|(txid, _)| *txid)
+                    .collect();
+                (deposits, withdrawals, reimbursements)
+            })
+            .await;
 
         // Update deposits incrementally
         let deposit_updates: Vec<(Txid, DepositInfo, u64)> = get_deposits(
             &rpc_manager,
-            &context.config,
+            context.config(),
             chain_tip_height,
             &active_deposits,
         )
@@ -370,20 +360,28 @@ pub async fn bridge_monitoring_task(
         .map(|(info, confirmations)| (info.deposit_request_txid, *info, *confirmations))
         .collect();
 
-        {
-            let mut cache = context.status_cache.write().await;
-            cache.apply_deposit_updates(deposit_updates);
+        let final_deposits = context
+            .with_state_mut(|cache| {
+                cache.apply_deposit_updates(deposit_updates);
 
-            // Determine deposits to purge after applying updates
-            let deposits_to_purge =
-                determine_deposits_to_purge(&cache, &context.config, chain_tip_height).await;
-            cache.purge_deposits(deposits_to_purge);
-        }
+                // Determine deposits to purge after applying updates.
+                cache.filter_deposits(|s| {
+                    matches!(s, DepositStatus::Complete | DepositStatus::Failed)
+                })
+            })
+            .await;
+        let deposits_to_purge =
+            determine_deposits_to_purge(final_deposits, context.config(), chain_tip_height).await;
+        context
+            .with_state_mut(|cache| {
+                cache.purge_deposits(deposits_to_purge);
+            })
+            .await;
 
         // Update withdrawals incrementally
         let withdrawal_updates: Vec<(Buf32, WithdrawalInfo, u64)> = get_withdrawals(
             &rpc_manager,
-            &context.config,
+            context.config(),
             chain_tip_height,
             &active_withdrawals,
         )
@@ -392,20 +390,27 @@ pub async fn bridge_monitoring_task(
         .map(|(info, confirmations)| (info.withdrawal_request_txid, *info, *confirmations))
         .collect();
 
-        {
-            let mut cache = context.status_cache.write().await;
-            cache.apply_withdrawal_updates(withdrawal_updates);
+        let final_withdrawals = context
+            .with_state_mut(|cache| {
+                cache.apply_withdrawal_updates(withdrawal_updates);
 
-            // Determine withdrawals to purge after applying updates
-            let withdrawals_to_purge =
-                determine_withdrawals_to_purge(&cache, &context.config, chain_tip_height).await;
-            cache.purge_withdrawals(withdrawals_to_purge);
-        }
+                // Determine withdrawals to purge after applying updates.
+                cache.filter_withdrawals(|s| matches!(s, WithdrawalStatus::Complete))
+            })
+            .await;
+        let withdrawals_to_purge =
+            determine_withdrawals_to_purge(final_withdrawals, context.config(), chain_tip_height)
+                .await;
+        context
+            .with_state_mut(|cache| {
+                cache.purge_withdrawals(withdrawals_to_purge);
+            })
+            .await;
 
         // Update reimbursements incrementally
         let reimbursement_updates: Vec<(Txid, ReimbursementInfo, u64)> = get_reimbursements(
             &rpc_manager,
-            &context.config,
+            context.config(),
             chain_tip_height,
             &active_reimbursements,
         )
@@ -414,21 +419,33 @@ pub async fn bridge_monitoring_task(
         .map(|(info, confirmations)| (info.claim_txid, *info, *confirmations))
         .collect();
 
-        {
-            let mut cache = context.status_cache.write().await;
-            cache.apply_reimbursement_updates(reimbursement_updates);
+        let final_reimbursements = context
+            .with_state_mut(|cache| {
+                cache.apply_reimbursement_updates(reimbursement_updates);
 
-            // Determine reimbursements to purge after applying updates
-            let reimbursements_to_purge =
-                determine_reimbursements_to_purge(&cache, &context.config, chain_tip_height).await;
-            cache.purge_reimbursements(reimbursements_to_purge);
-        }
+                // Determine reimbursements to purge after applying updates.
+                cache.filter_reimbursements(|s| {
+                    matches!(
+                        s,
+                        ReimbursementStatus::Complete | ReimbursementStatus::Cancelled
+                    )
+                })
+            })
+            .await;
+        let reimbursements_to_purge = determine_reimbursements_to_purge(
+            final_reimbursements,
+            context.config(),
+            chain_tip_height,
+        )
+        .await;
+        context
+            .with_state_mut(|cache| {
+                cache.purge_reimbursements(reimbursements_to_purge);
+            })
+            .await;
 
         // Mark initial status query as complete and notify waiters
-        if !context.status_available.load(Ordering::Acquire) {
-            context.status_available.store(true, Ordering::Release);
-            context.initial_status_query_complete.notify_waiters();
-        }
+        context.mark_status_available();
     }
 
     Ok(())
@@ -818,32 +835,7 @@ async fn get_reimbursements(
 
 /// Return latest bridge status extracted from cache
 pub async fn get_bridge_status(context: Arc<BridgeMonitoringContext>) -> Json<BridgeStatus> {
-    // Wait for initial status query to complete if not yet available
-    if !context.status_available.load(Ordering::Acquire) {
-        info!("waiting for initial bridge status query to complete");
-        context.initial_status_query_complete.notified().await;
-    }
+    context.wait_until_status_available().await;
 
-    let cache = context.status_cache.read().await;
-
-    let bridge_status = BridgeStatus {
-        operators: cache.get_operators(),
-        deposits: cache
-            .filter_deposits(|_| true)
-            .into_iter()
-            .map(|(_, info)| info)
-            .collect(),
-        withdrawals: cache
-            .filter_withdrawals(|_| true)
-            .into_iter()
-            .map(|(_, info)| info)
-            .collect(),
-        reimbursements: cache
-            .filter_reimbursements(|_| true)
-            .into_iter()
-            .map(|(_, info)| info)
-            .collect(),
-    };
-
-    Json(bridge_status)
+    Json(context.bridge_status().await)
 }

--- a/backend/crates/bridge/src/types.rs
+++ b/backend/crates/bridge/src/types.rs
@@ -1,16 +1,10 @@
 use bitcoin::{secp256k1::PublicKey, Txid};
 use serde::{Deserialize, Serialize};
-use std::sync::{atomic::AtomicBool, Arc};
 use strata_bridge_rpc::types::{
     RpcClaimInfo, RpcDepositInfo, RpcDepositStatus, RpcOperatorStatus, RpcReimbursementStatus,
     RpcWithdrawalInfo, RpcWithdrawalStatus,
 };
 use strata_primitives::buf::Buf32;
-use tokio::sync::{Notify, RwLock};
-
-use status_config::BridgeMonitoringConfig;
-
-use super::cache::BridgeStatusCache;
 
 /// Bridge operator status
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -185,23 +179,4 @@ pub struct BridgeStatus {
     pub(crate) deposits: Vec<DepositInfo>,
     pub(crate) withdrawals: Vec<WithdrawalInfo>,
     pub(crate) reimbursements: Vec<ReimbursementInfo>,
-}
-
-/// Bridge monitoring context
-pub struct BridgeMonitoringContext {
-    pub(crate) status_cache: Arc<RwLock<BridgeStatusCache>>,
-    pub(crate) config: BridgeMonitoringConfig,
-    pub(crate) status_available: Arc<AtomicBool>,
-    pub(crate) initial_status_query_complete: Arc<Notify>,
-}
-
-impl BridgeMonitoringContext {
-    pub fn new(config: BridgeMonitoringConfig) -> Self {
-        Self {
-            status_cache: Arc::new(RwLock::new(BridgeStatusCache::default())),
-            config,
-            status_available: Arc::new(AtomicBool::new(false)),
-            initial_status_query_complete: Arc::new(Notify::new()),
-        }
-    }
 }

--- a/backend/crates/network/src/status.rs
+++ b/backend/crates/network/src/status.rs
@@ -75,10 +75,10 @@ pub async fn fetch_statuses_task(
 ) -> Result<()> {
     info!("fetching network statuses");
     let mut interval = interval(Duration::from_secs(
-        context.config.status_refetch_interval(),
+        context.config().status_refetch_interval(),
     ));
-    let sequencer_client = create_rpc_client(context.config.sequencer_url());
-    let rpc_client = create_rpc_client(context.config.rpc_url());
+    let sequencer_client = create_rpc_client(context.config().sequencer_url());
+    let rpc_client = create_rpc_client(context.config().rpc_url());
     let http_client = reqwest::Client::new();
 
     loop {
@@ -88,30 +88,16 @@ pub async fn fetch_statuses_task(
         }
 
         let sequencer =
-            call_rpc_status(&sequencer_client, context.config.sequencer_retry_policy()).await;
-        let rpc_endpoint = call_rpc_status(&rpc_client, context.config.rpc_retry_policy()).await;
-        let bundler_endpoint = check_bundler_health(&http_client, &context.config).await;
+            call_rpc_status(&sequencer_client, context.config().sequencer_retry_policy()).await;
+        let rpc_endpoint = call_rpc_status(&rpc_client, context.config().rpc_retry_policy()).await;
+        let bundler_endpoint = check_bundler_health(&http_client, context.config()).await;
 
-        let new_status = NetworkStatus {
-            sequencer,
-            rpc_endpoint,
-            bundler_endpoint,
-        };
+        let new_status = NetworkStatus::new(sequencer, rpc_endpoint, bundler_endpoint);
 
         info!(?new_status, "updated network status");
 
-        let mut locked_status = context.network_status.write().await;
-        *locked_status = new_status;
-
-        if !context
-            .status_available
-            .load(std::sync::atomic::Ordering::Acquire)
-        {
-            context
-                .status_available
-                .store(true, std::sync::atomic::Ordering::Release);
-            context.initial_status_query_complete.notify_waiters();
-        }
+        context.set_status(new_status).await;
+        context.mark_status_available();
     }
 
     Ok(())
@@ -119,15 +105,7 @@ pub async fn fetch_statuses_task(
 
 /// Handler to get the current network status
 pub async fn get_network_status(context: Arc<NetworkMonitoringContext>) -> Json<NetworkStatus> {
-    // Wait for initial status query to complete if not yet available
-    if !context
-        .status_available
-        .load(std::sync::atomic::Ordering::Acquire)
-    {
-        info!("waiting for initial network status query to complete");
-        context.initial_status_query_complete.notified().await;
-    }
+    context.wait_until_status_available().await;
 
-    let data = context.network_status.read().await.clone();
-    Json(data)
+    Json(context.status().await)
 }

--- a/backend/crates/network/src/types.rs
+++ b/backend/crates/network/src/types.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
-use std::sync::{atomic::AtomicBool, Arc};
+use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::{Notify, RwLock};
+use tracing::debug;
 
 use status_config::NetworkMonitoringConfig;
 
@@ -13,9 +14,9 @@ pub(crate) enum Status {
 
 #[derive(Serialize, Clone, Debug)]
 pub struct NetworkStatus {
-    pub(crate) sequencer: Status,
-    pub(crate) rpc_endpoint: Status,
-    pub(crate) bundler_endpoint: Status,
+    sequencer: Status,
+    rpc_endpoint: Status,
+    bundler_endpoint: Status,
 }
 
 impl Default for NetworkStatus {
@@ -28,21 +29,61 @@ impl Default for NetworkStatus {
     }
 }
 
+impl NetworkStatus {
+    pub(crate) fn new(sequencer: Status, rpc_endpoint: Status, bundler_endpoint: Status) -> Self {
+        Self {
+            sequencer,
+            rpc_endpoint,
+            bundler_endpoint,
+        }
+    }
+}
+
 /// Network monitoring context
 pub struct NetworkMonitoringContext {
-    pub(crate) network_status: Arc<RwLock<NetworkStatus>>,
-    pub(crate) config: NetworkMonitoringConfig,
-    pub(crate) status_available: Arc<AtomicBool>,
-    pub(crate) initial_status_query_complete: Arc<Notify>,
+    config: NetworkMonitoringConfig,
+    status_available: AtomicBool,
+    initial_status_query_complete: Notify,
+    network_status: RwLock<NetworkStatus>,
 }
 
 impl NetworkMonitoringContext {
     pub fn new(config: NetworkMonitoringConfig) -> Self {
         Self {
-            network_status: Arc::new(RwLock::new(NetworkStatus::default())),
             config,
-            status_available: Arc::new(AtomicBool::new(false)),
-            initial_status_query_complete: Arc::new(Notify::new()),
+            status_available: AtomicBool::new(false),
+            initial_status_query_complete: Notify::new(),
+            network_status: RwLock::new(NetworkStatus::default()),
+        }
+    }
+
+    pub(crate) fn config(&self) -> &NetworkMonitoringConfig {
+        &self.config
+    }
+
+    pub(crate) async fn set_status(&self, status: NetworkStatus) {
+        let mut locked_status = self.network_status.write().await;
+        *locked_status = status;
+    }
+
+    pub(crate) async fn status(&self) -> NetworkStatus {
+        self.network_status.read().await.clone()
+    }
+
+    pub(crate) fn mark_status_available(&self) {
+        if self
+            .status_available
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            self.initial_status_query_complete.notify_waiters();
+        }
+    }
+
+    pub(crate) async fn wait_until_status_available(&self) {
+        if !self.status_available.load(Ordering::Acquire) {
+            debug!("Waiting for initial network status query to complete");
+            self.initial_status_query_complete.notified().await;
         }
     }
 }


### PR DESCRIPTION
## Description

Encapsulate monitoring context state behind private accessors. Replace direct field/lock access with method calls (`config()`, `with_state` / `with_state_mut`, `mark_status_available`, `wait_until_status_available`, `bridge_status` / `status`).

- **Bridge**: new `context` module so `types.rs` stays data-only. Polling task switches to a closure-based lock API, so the purge step runs Esplora roundtrips outside the cache write lock instead of holding it across N HTTP calls.
- **Network**: same shape, single-value status path (`set_status` / `status`).

No frontend or RPC contract changes.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor 

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 