### PR TITLE
refactor: split status backend into RPC, Esplora, and task modules

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -27,13 +27,13 @@
       "client",
     ], rev = "851a681200658a19d88493a70f3bed66e515a08b" }
     strata-primitives = { git = "https://github.com/alpenlabs/alpen.git", rev = "565fafccf2fe181d2f93003f9135ceed126a01ad" }
-    strata-tasks      = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc16" }
-    typed-sled        = { git = "https://github.com/alpenlabs/typed-sled" }
+    strata-tasks = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc16" }
+    typed-sled = { git = "https://github.com/alpenlabs/typed-sled" }
 
     # External
-    anyhow = { version = "1" }
     alloy-primitives = { version = "1.4.1", features = [ "serde" ] }
-    alloy-sol-types  = { version = "1.4.1" }
+    alloy-sol-types = { version = "1.4.1" }
+    anyhow = { version = "1" }
     axum = { version = "0.8" }
     bitcoin = { version = "0.32.8", features = [ "serde" ] }
     hex = { version = "0.4" }
@@ -44,7 +44,7 @@
       "alloc",
       "raw_value",
     ] }
-    sled      = { version = "0.34" }
+    sled = { version = "0.34" }
     thiserror = { version = "1" }
     tokio = { version = "1.52.1", features = [ "macros", "rt-multi-thread" ] }
     toml = { version = "1.1.2" }

--- a/backend/bin/dashboard/src/main.rs
+++ b/backend/bin/dashboard/src/main.rs
@@ -6,7 +6,7 @@ use status_bridge::{
     bridge_monitoring_task, get_bridge_status, run_withdrawal_indexer, BridgeMonitoringContext,
 };
 use status_config::Config;
-use status_network::{fetch_statuses_task, get_network_status, NetworkMonitoringContext};
+use status_network::{get_network_status, network_monitoring_task, NetworkMonitoringContext};
 use strata_tasks::TaskManager;
 use tokio::{net::TcpListener, runtime};
 use tower_http::cors::{Any, CorsLayer};
@@ -58,7 +58,7 @@ fn main() -> Result<()> {
 
     executor.spawn_critical_async_with_shutdown("network-monitoring", {
         let network_context = Arc::clone(&network_context);
-        move |shutdown| async move { fetch_statuses_task(network_context, shutdown).await }
+        move |shutdown| async move { network_monitoring_task(network_context, shutdown).await }
     });
 
     executor.spawn_critical_async_with_shutdown("bridge-monitoring", {

--- a/backend/crates/bridge/src/bridge_rpc.rs
+++ b/backend/crates/bridge/src/bridge_rpc.rs
@@ -1,0 +1,281 @@
+use anyhow::Result;
+use bitcoin::Txid;
+use jsonrpsee::http_client::HttpClient;
+use std::collections::BTreeMap;
+use strata_bridge_rpc::traits::{StrataBridgeControlApiClient, StrataBridgeMonitoringApiClient};
+use strata_bridge_rpc::types::{
+    RpcClaimInfo, RpcDepositInfo, RpcOperatorStatus, RpcWithdrawalInfo,
+};
+use strata_primitives::buf::Buf32;
+use tracing::{debug, warn};
+
+use status_config::BridgeMonitoringConfig;
+use status_utils::{create_rpc_client, execute_with_retries};
+
+/// RPC client manager with connection pooling and retry logic
+///
+/// This manager maintains a pool of reusable HTTP clients for each bridge operator,
+/// preventing connection exhaustion by reusing clients across requests. It implements
+/// automatic retry logic with exponential backoff to handle transient network failures.
+///
+/// # Design
+///
+/// - **Connection Pooling**: Creates one HTTP client per operator and reuses it for all requests
+/// - **Retry Logic**: Implements exponential backoff (3 retries over 10 seconds with 1.5x multiplier)
+/// - **Failover**: Tries all available operators in deterministic order (sorted by public key)
+/// - **Graceful Degradation**: Returns `None` if all operators fail after retries
+///
+/// # Example Flow
+///
+/// For each RPC request:
+///
+/// 1. Try operator 1 with up to 3 retries (exponential backoff between retries)
+/// 2. If operator 1 fails after retries, try operator 2 with up to 3 retries
+/// 3. Continue until an operator succeeds or all fail
+/// 4. Return the first successful result or [`None`] if all fail
+pub(crate) struct RpcClientManager {
+    /// HTTP clients for each operator, keyed by operator public key ([`String`])
+    /// [`BTreeMap`] ensures deterministic ordering (sorted by key)
+    clients: BTreeMap<String, HttpClient>,
+}
+
+impl RpcClientManager {
+    /// Create a new RPC client manager for the configured bridge operators
+    ///
+    /// This initializes one HTTP client per operator with:
+    ///
+    /// - 30-second request timeout
+    /// - 10MB max request size
+    /// - Connection pooling enabled
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - Bridge monitoring configuration containing operator RPC URLs
+    pub(crate) fn new(config: &BridgeMonitoringConfig) -> Self {
+        let mut clients = BTreeMap::new();
+        for operator in config.operators() {
+            clients.insert(
+                operator.public_key().to_string(),
+                create_rpc_client(operator.rpc_url()),
+            );
+        }
+
+        Self { clients }
+    }
+
+    /// Execute an async operation across all available clients with retry logic
+    ///
+    /// This method tries the given operation on each operator sequentially (in sorted order
+    /// by public key). For each operator, it retries up to 3 times with exponential
+    /// backoff between attempts using [`execute_with_retries`]. The first successful result
+    /// is returned immediately.
+    ///
+    /// # Type Parameters
+    ///
+    /// * `T` - The expected return type of the operation
+    /// * `F` - A function that takes an [`HttpClient`] and returns a future
+    /// * `Fut` - The future returned by `F`
+    ///
+    /// # Arguments
+    ///
+    /// * `operation` - A closure that performs an RPC call using the provided client
+    ///
+    /// # Returns
+    ///
+    /// * [`Some(T)`](Some) - If any operator succeeds (possibly after retries)
+    /// * [`None`] - If all operators fail after exhausting their retries
+    ///
+    /// # Retry Behavior
+    ///
+    /// Uses [`execute_with_retries`] for each operator with exponential backoff:
+    ///
+    /// - **Attempt 0**: Immediate (no delay)
+    /// - **Attempt 1**: After ~2s delay
+    /// - **Attempt 2**: After ~3s delay
+    /// - **Attempt 3**: After ~5s delay
+    /// - Total: ~10 seconds per operator
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let result = rpc_manager
+    ///     .query_clients_with_retry(|client| async move {
+    ///         client.get_deposit_requests().await.map_err(|e| e.into())
+    ///     })
+    ///     .await;
+    /// ```
+    async fn query_clients_with_retry<T, F, Fut>(&self, operation: F) -> Option<T>
+    where
+        F: Fn(HttpClient) -> Fut,
+        Fut: std::future::Future<Output = Result<T, Box<dyn std::error::Error + Send + Sync>>>,
+    {
+        // BTreeMap maintains sorted order automatically
+        for (key, client) in self.clients.iter() {
+            let client_clone = client.clone();
+            let operation_name = format!("RPC request to operator public key {key}");
+
+            match execute_with_retries(
+                || {
+                    let client = client_clone.clone();
+                    operation(client)
+                },
+                &operation_name,
+            )
+            .await
+            {
+                Ok(result) => {
+                    debug!(operator_pk = %key, "rpc request succeeded");
+                    return Some(result);
+                }
+                Err(e) => {
+                    warn!(
+                        operator_pk = %key,
+                        error = %e,
+                        "rpc request failed after retries"
+                    );
+                    // Continue to next operator
+                }
+            }
+        }
+
+        None
+    }
+}
+
+/// Fetch operator status.
+pub(crate) async fn get_operator_status(rpc_url: &str) -> RpcOperatorStatus {
+    let rpc_client = create_rpc_client(rpc_url);
+
+    // Directly use `get_uptime`
+    if rpc_client.get_uptime().await.is_ok() {
+        RpcOperatorStatus::Online
+    } else {
+        warn!("failed to fetch bridge operator uptime");
+        RpcOperatorStatus::Offline
+    }
+}
+
+/// Fetch all pending deposit request transaction IDs from bridge operators.
+///
+/// Uses the RPC client manager with retry logic to query all operators for their
+/// list of deposit requests. Returns the first non-empty result, or an empty vector
+/// if all operators have no deposits or all fail.
+///
+/// # Arguments
+///
+/// * `rpc_manager` - RPC client manager with retry/failover logic
+///
+/// # Returns
+///
+/// Vector of deposit request transaction IDs. Empty if no deposits found or all operators failed.
+pub(crate) async fn get_deposit_requests(rpc_manager: &RpcClientManager) -> Vec<Txid> {
+    let result = rpc_manager
+        .query_clients_with_retry(|client| async move {
+            client.get_deposit_requests().await.map_err(|e| e.into())
+        })
+        .await;
+
+    result.unwrap_or_else(|| {
+        warn!("no deposit requests found from any operator");
+        Vec::new()
+    })
+}
+
+/// Fetch deposit request information from bridge operators.
+pub(crate) async fn get_deposit_request_info(
+    rpc_manager: &RpcClientManager,
+    txid: Txid,
+) -> Option<RpcDepositInfo> {
+    rpc_manager
+        .query_clients_with_retry(|client| async move {
+            client
+                .get_deposit_request_info(txid)
+                .await
+                .map_err(|e| e.into())
+        })
+        .await
+}
+
+/// Fetch all pending withdrawal request IDs from bridge operators.
+///
+/// Uses the RPC client manager with retry logic to query all operators for their
+/// list of withdrawal requests. Returns the first non-empty result, or an empty vector
+/// if all operators have no withdrawals or all fail.
+///
+/// # Arguments
+///
+/// * `rpc_manager` - RPC client manager with retry/failover logic
+///
+/// # Returns
+///
+/// Vector of withdrawal request IDs. Empty if no withdrawals found or all operators failed.
+pub(crate) async fn get_withdrawal_requests(rpc_manager: &RpcClientManager) -> Vec<Buf32> {
+    let result = rpc_manager
+        .query_clients_with_retry(|client| async move {
+            client.get_withdrawals().await.map_err(|e| e.into())
+        })
+        .await;
+
+    result.unwrap_or_else(|| {
+        warn!("no withdrawal requests found from any operator");
+        Vec::new()
+    })
+}
+
+/// Fetch withdrawal information from bridge operators.
+pub(crate) async fn get_withdrawal_info(
+    rpc_manager: &RpcClientManager,
+    request_id: Buf32,
+) -> Option<RpcWithdrawalInfo> {
+    rpc_manager
+        .query_clients_with_retry(|client| async move {
+            match client.get_withdrawal_info(request_id).await {
+                Ok(Some(info)) => Ok(info),
+                Ok(None) => Err("No withdrawal info found".into()),
+                Err(e) => Err(e.into()),
+            }
+        })
+        .await
+}
+
+/// Fetch all pending claim transaction IDs from bridge operators.
+///
+/// Uses the RPC client manager with retry logic to query all operators for their
+/// list of claim transactions. Returns the first non-empty result, or an empty vector
+/// if all operators have no claims or all fail.
+///
+/// # Arguments
+///
+/// * `rpc_manager` - RPC client manager with retry/failover logic
+///
+/// # Returns
+///
+/// Vector of claim transaction IDs. Empty if no claims found or all operators failed.
+pub(crate) async fn get_claims(rpc_manager: &RpcClientManager) -> Vec<Txid> {
+    let result = rpc_manager
+        .query_clients_with_retry(|client| async move {
+            client.get_claims().await.map_err(|e| e.into())
+        })
+        .await;
+
+    result.unwrap_or_else(|| {
+        warn!("no claims found from any operator");
+        Vec::new()
+    })
+}
+
+/// Fetch claim information from bridge operators.
+pub(crate) async fn get_claim_info(
+    rpc_manager: &RpcClientManager,
+    txid: Txid,
+) -> Option<RpcClaimInfo> {
+    rpc_manager
+        .query_clients_with_retry(|client| async move {
+            match client.get_claim_info(txid).await {
+                Ok(Some(info)) => Ok(info),
+                Ok(None) => Err("No claim info found".into()),
+                Err(e) => Err(e.into()),
+            }
+        })
+        .await
+}

--- a/backend/crates/bridge/src/esplora.rs
+++ b/backend/crates/bridge/src/esplora.rs
@@ -1,0 +1,127 @@
+use anyhow::Result;
+use bitcoin::Txid;
+use serde::Deserialize;
+use std::time::Duration;
+use strata_primitives::L1Height;
+use tracing::error;
+
+#[derive(Deserialize)]
+struct TxStatus {
+    confirmed: bool,
+    block_height: Option<L1Height>,
+}
+
+pub(crate) struct EsploraClient {
+    base_url: String,
+    client: reqwest::Client,
+}
+
+impl EsploraClient {
+    pub(crate) fn new(esplora_url: &str, request_timeout_s: u64) -> Self {
+        Self {
+            base_url: esplora_url.trim_end_matches('/').to_string(),
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(request_timeout_s))
+                .build()
+                .expect("failed to create Esplora HTTP client"),
+        }
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{path}", self.base_url)
+    }
+
+    async fn get_tip_height(&self) -> reqwest::Result<String> {
+        let resp = self
+            .client
+            .get(self.url("/blocks/tip/height"))
+            .send()
+            .await?;
+        resp.text().await
+    }
+
+    async fn get_tx_status(&self, txid: Txid) -> Option<TxStatus> {
+        let status_path = format!("/tx/{txid}/status");
+        let status_resp = self.client.get(self.url(&status_path)).send().await;
+
+        match status_resp {
+            Ok(resp) => match resp.json().await {
+                Ok(status) => Some(status),
+                Err(e) => {
+                    error!(%txid, error = %e, "failed to parse tx status JSON from esplora");
+                    None
+                }
+            },
+            Err(e) => {
+                error!(%txid, error = %e, "failed to fetch tx status from esplora");
+                None
+            }
+        }
+    }
+}
+
+/// Fetch bitcoin chain tip height.
+pub(crate) async fn get_bitcoin_chain_tip_height(
+    esplora_client: &EsploraClient,
+) -> Result<L1Height> {
+    let text = esplora_client.get_tip_height().await?;
+    let height = text.trim().parse::<L1Height>()?;
+    Ok(height)
+}
+
+/// Get transaction confirmations from esplora.
+pub(crate) async fn get_tx_confirmations(
+    esplora_client: &EsploraClient,
+    txid: Txid,
+    chain_tip_height: L1Height,
+) -> Option<u64> {
+    let status = esplora_client.get_tx_status(txid).await?;
+
+    status
+        .block_height
+        .filter(|_| status.confirmed)
+        .map(|height| confirmations_from_block_height(chain_tip_height, height))
+}
+
+fn confirmations_from_block_height(chain_tip_height: L1Height, block_height: L1Height) -> u64 {
+    u64::from(chain_tip_height.saturating_sub(block_height) + 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn esplora_client_normalizes_base_url_once() {
+        let client = EsploraClient::new("http://localhost:3002///", 5);
+
+        assert_eq!(
+            client.url("/blocks/tip/height"),
+            "http://localhost:3002/blocks/tip/height"
+        );
+        assert_eq!(
+            client.url("/tx/abc/status"),
+            "http://localhost:3002/tx/abc/status"
+        );
+    }
+
+    #[test]
+    fn tx_status_deserializes_l1_height_from_esplora_json() {
+        let status: TxStatus =
+            serde_json::from_str(r#"{"confirmed":true,"block_height":12345}"#).unwrap();
+
+        assert!(status.confirmed);
+        assert_eq!(status.block_height, Some(12345 as L1Height));
+    }
+
+    #[test]
+    fn confirmations_from_block_height_counts_tip_as_one_confirmation() {
+        assert_eq!(confirmations_from_block_height(100, 100), 1);
+        assert_eq!(confirmations_from_block_height(100, 98), 3);
+    }
+
+    #[test]
+    fn confirmations_from_block_height_saturates_for_future_height() {
+        assert_eq!(confirmations_from_block_height(100, 101), 1);
+    }
+}

--- a/backend/crates/bridge/src/lib.rs
+++ b/backend/crates/bridge/src/lib.rs
@@ -2,6 +2,7 @@ mod bridge_rpc;
 mod cache;
 mod context;
 mod db;
+mod esplora;
 mod status;
 mod types;
 mod withdrawal_indexer;

--- a/backend/crates/bridge/src/lib.rs
+++ b/backend/crates/bridge/src/lib.rs
@@ -1,3 +1,4 @@
+mod bridge_rpc;
 mod cache;
 mod context;
 mod db;

--- a/backend/crates/bridge/src/status.rs
+++ b/backend/crates/bridge/src/status.rs
@@ -1,19 +1,14 @@
 use anyhow::Result;
 use axum::Json;
 use bitcoin::{secp256k1::PublicKey, Txid};
-
-use jsonrpsee::http_client::HttpClient;
-use std::collections::BTreeMap;
 use std::sync::Arc;
-use strata_bridge_rpc::traits::{StrataBridgeControlApiClient, StrataBridgeMonitoringApiClient};
-use strata_bridge_rpc::types::{
-    RpcDepositStatus, RpcOperatorStatus, RpcReimbursementStatus, RpcWithdrawalStatus,
-};
+use strata_bridge_rpc::types::{RpcDepositStatus, RpcReimbursementStatus, RpcWithdrawalStatus};
 
 use strata_primitives::buf::Buf32;
 use strata_tasks::ShutdownGuard;
 
 use super::{
+    bridge_rpc::{self, RpcClientManager},
     context::BridgeMonitoringContext,
     types::{
         BridgeStatus, DepositInfo, DepositStatus, OperatorStatus, ReimbursementInfo,
@@ -22,140 +17,9 @@ use super::{
 };
 
 use tokio::time::{interval, Duration};
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 
 use status_config::BridgeMonitoringConfig;
-use status_utils::{create_rpc_client, execute_with_retries};
-
-/// RPC client manager with connection pooling and retry logic
-///
-/// This manager maintains a pool of reusable HTTP clients for each bridge operator,
-/// preventing connection exhaustion by reusing clients across requests. It implements
-/// automatic retry logic with exponential backoff to handle transient network failures.
-///
-/// # Design
-///
-/// - **Connection Pooling**: Creates one HTTP client per operator and reuses it for all requests
-/// - **Retry Logic**: Implements exponential backoff (3 retries over 10 seconds with 1.5x multiplier)
-/// - **Failover**: Tries all available operators in deterministic order (sorted by public key)
-/// - **Graceful Degradation**: Returns `None` if all operators fail after retries
-///
-/// # Example Flow
-///
-/// For each RPC request:
-///
-/// 1. Try operator 1 with up to 3 retries (exponential backoff between retries)
-/// 2. If operator 1 fails after retries, try operator 2 with up to 3 retries
-/// 3. Continue until an operator succeeds or all fail
-/// 4. Return the first successful result or [`None`] if all fail
-struct RpcClientManager {
-    /// HTTP clients for each operator, keyed by operator public key ([`String`])
-    /// [`BTreeMap`] ensures deterministic ordering (sorted by key)
-    clients: BTreeMap<String, HttpClient>,
-}
-
-impl RpcClientManager {
-    /// Create a new RPC client manager for the configured bridge operators
-    ///
-    /// This initializes one HTTP client per operator with:
-    ///
-    /// - 30-second request timeout
-    /// - 10MB max request size
-    /// - Connection pooling enabled
-    ///
-    /// # Arguments
-    ///
-    /// * `config` - Bridge monitoring configuration containing operator RPC URLs
-    fn new(config: &BridgeMonitoringConfig) -> Self {
-        let mut clients = BTreeMap::new();
-        for operator in config.operators() {
-            clients.insert(
-                operator.public_key().to_string(),
-                create_rpc_client(operator.rpc_url()),
-            );
-        }
-
-        Self { clients }
-    }
-
-    /// Execute an async operation across all available clients with retry logic
-    ///
-    /// This method tries the given operation on each operator sequentially (in sorted order
-    /// by public key). For each operator, it retries up to 3 times with exponential
-    /// backoff between attempts using [`execute_with_retries`]. The first successful result
-    /// is returned immediately.
-    ///
-    /// # Type Parameters
-    ///
-    /// * `T` - The expected return type of the operation
-    /// * `F` - A function that takes an [`HttpClient`] and returns a future
-    /// * `Fut` - The future returned by `F`
-    ///
-    /// # Arguments
-    ///
-    /// * `operation` - A closure that performs an RPC call using the provided client
-    ///
-    /// # Returns
-    ///
-    /// * [`Some(T)`](Some) - If any operator succeeds (possibly after retries)
-    /// * [`None`] - If all operators fail after exhausting their retries
-    ///
-    /// # Retry Behavior
-    ///
-    /// Uses [`execute_with_retries`] for each operator with exponential backoff:
-    ///
-    /// - **Attempt 0**: Immediate (no delay)
-    /// - **Attempt 1**: After ~2s delay
-    /// - **Attempt 2**: After ~3s delay  
-    /// - **Attempt 3**: After ~5s delay
-    /// - Total: ~10 seconds per operator
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// let result = rpc_manager
-    ///     .query_clients_with_retry(|client| async move {
-    ///         client.get_deposit_requests().await.map_err(|e| e.into())
-    ///     })
-    ///     .await;
-    /// ```
-    async fn query_clients_with_retry<T, F, Fut>(&self, operation: F) -> Option<T>
-    where
-        F: Fn(HttpClient) -> Fut,
-        Fut: std::future::Future<Output = Result<T, Box<dyn std::error::Error + Send + Sync>>>,
-    {
-        // BTreeMap maintains sorted order automatically
-        for (key, client) in self.clients.iter() {
-            let client_clone = client.clone();
-            let operation_name = format!("RPC request to operator public key {key}");
-
-            match execute_with_retries(
-                || {
-                    let client = client_clone.clone();
-                    operation(client)
-                },
-                &operation_name,
-            )
-            .await
-            {
-                Ok(result) => {
-                    debug!(operator_pk = %key, "rpc request succeeded");
-                    return Some(result);
-                }
-                Err(e) => {
-                    warn!(
-                        operator_pk = %key,
-                        error = %e,
-                        "rpc request failed after retries"
-                    );
-                    // Continue to next operator
-                }
-            }
-        }
-
-        None
-    }
-}
 
 /// Get transaction confirmations from esplora
 async fn get_tx_confirmations(esplora_url: &str, txid: Txid, chain_tip_height: u64) -> Option<u64> {
@@ -300,7 +164,7 @@ pub async fn bridge_monitoring_task(
             let operator_id = format!("Alpen Labs #{}", index + 1);
             let pk_bytes = hex::decode(operator.public_key()).expect("decode to succeed");
             let operator_pk = PublicKey::from_slice(&pk_bytes).expect("conversion to succeed");
-            let status = get_operator_status(operator.rpc_url()).await;
+            let status = bridge_rpc::get_operator_status(operator.rpc_url()).await;
             operator_statuses.push(OperatorStatus::new(operator_id, operator_pk, status));
         }
 
@@ -451,19 +315,6 @@ pub async fn bridge_monitoring_task(
     Ok(())
 }
 
-/// Fetch operator status
-async fn get_operator_status(rpc_url: &str) -> RpcOperatorStatus {
-    let rpc_client = create_rpc_client(rpc_url);
-
-    // Directly use `get_uptime`
-    if rpc_client.get_uptime().await.is_ok() {
-        RpcOperatorStatus::Online
-    } else {
-        warn!("failed to fetch bridge operator uptime");
-        RpcOperatorStatus::Offline
-    }
-}
-
 /// Fetch bitcoin chain tip height
 async fn get_bitcoin_chain_tip_height(
     esplora_url: &str,
@@ -474,32 +325,6 @@ async fn get_bitcoin_chain_tip_height(
     let text = resp.text().await?;
     let height = text.trim().parse::<u64>()?;
     Ok(height)
-}
-
-/// Fetch all pending deposit request transaction IDs from bridge operators
-///
-/// Uses the RPC client manager with retry logic to query all operators for their
-/// list of deposit requests. Returns the first non-empty result, or an empty vector
-/// if all operators have no deposits or all fail.
-///
-/// # Arguments
-///
-/// * `rpc_manager` - RPC client manager with retry/failover logic
-///
-/// # Returns
-///
-/// Vector of deposit request transaction IDs. Empty if no deposits found or all operators failed.
-async fn get_deposit_requests(rpc_manager: &RpcClientManager) -> Vec<Txid> {
-    let result = rpc_manager
-        .query_clients_with_retry(|client| async move {
-            client.get_deposit_requests().await.map_err(|e| e.into())
-        })
-        .await;
-
-    result.unwrap_or_else(|| {
-        warn!("no deposit requests found from any operator");
-        Vec::new()
-    })
 }
 
 /// Fetch detailed information for all deposit requests
@@ -529,7 +354,7 @@ async fn get_deposits(
     chain_tip_height: u64,
     active_deposit_txids: &[Txid],
 ) -> Vec<(DepositInfo, u64)> {
-    let new_deposit_requests = get_deposit_requests(rpc_manager).await;
+    let new_deposit_requests = bridge_rpc::get_deposit_requests(rpc_manager).await;
     let new_count = new_deposit_requests.len();
     let mut deposit_requests = new_deposit_requests;
 
@@ -550,14 +375,7 @@ async fn get_deposits(
     let mut deposit_infos: Vec<(DepositInfo, u64)> = Vec::new();
     for deposit_request_txid in deposit_requests.iter() {
         let txid = *deposit_request_txid;
-        let rpc_info = rpc_manager
-            .query_clients_with_retry(|client| async move {
-                client
-                    .get_deposit_request_info(txid)
-                    .await
-                    .map_err(|e| e.into())
-            })
-            .await;
+        let rpc_info = bridge_rpc::get_deposit_request_info(rpc_manager, txid).await;
 
         let Some(dep_info) = rpc_info else {
             error!(%deposit_request_txid, "failed to fetch deposit info after retries");
@@ -594,32 +412,6 @@ async fn get_deposits(
     deposit_infos
 }
 
-/// Fetch all pending withdrawal request IDs from bridge operators
-///
-/// Uses the RPC client manager with retry logic to query all operators for their
-/// list of withdrawal requests. Returns the first non-empty result, or an empty vector
-/// if all operators have no withdrawals or all fail.
-///
-/// # Arguments
-///
-/// * `rpc_manager` - RPC client manager with retry/failover logic
-///
-/// # Returns
-///
-/// Vector of withdrawal request IDs. Empty if no withdrawals found or all operators failed.
-async fn get_withdrawal_requests(rpc_manager: &RpcClientManager) -> Vec<Buf32> {
-    let result = rpc_manager
-        .query_clients_with_retry(|client| async move {
-            client.get_withdrawals().await.map_err(|e| e.into())
-        })
-        .await;
-
-    result.unwrap_or_else(|| {
-        warn!("no withdrawal requests found from any operator");
-        Vec::new()
-    })
-}
-
 /// Fetch detailed information for all withdrawal requests and fulfillments
 ///
 /// Queries bridge operators for withdrawal details, including both new withdrawal requests
@@ -646,7 +438,7 @@ async fn get_withdrawals(
     chain_tip_height: u64,
     active_withdrawal_request_ids: &[Buf32],
 ) -> Vec<(WithdrawalInfo, u64)> {
-    let new_withdrawal_requests = get_withdrawal_requests(rpc_manager).await;
+    let new_withdrawal_requests = bridge_rpc::get_withdrawal_requests(rpc_manager).await;
     let new_count = new_withdrawal_requests.len();
     let mut withdrawal_requests = new_withdrawal_requests;
 
@@ -667,15 +459,7 @@ async fn get_withdrawals(
     let mut withdrawal_infos: Vec<(WithdrawalInfo, u64)> = Vec::new();
     for withdrawal_request_txid in withdrawal_requests.iter() {
         let request_id = *withdrawal_request_txid;
-        let rpc_info = rpc_manager
-            .query_clients_with_retry(|client| async move {
-                match client.get_withdrawal_info(request_id).await {
-                    Ok(Some(info)) => Ok(info),
-                    Ok(None) => Err("No withdrawal info found".into()),
-                    Err(e) => Err(e.into()),
-                }
-            })
-            .await;
+        let rpc_info = bridge_rpc::get_withdrawal_info(rpc_manager, request_id).await;
 
         let Some(wd_info) = rpc_info else {
             error!(%withdrawal_request_txid, "failed to fetch withdrawal info after retries");
@@ -707,32 +491,6 @@ async fn get_withdrawals(
     withdrawal_infos
 }
 
-/// Fetch all pending claim transaction IDs from bridge operators
-///
-/// Uses the RPC client manager with retry logic to query all operators for their
-/// list of claim transactions. Returns the first non-empty result, or an empty vector
-/// if all operators have no claims or all fail.
-///
-/// # Arguments
-///
-/// * `rpc_manager` - RPC client manager with retry/failover logic
-///
-/// # Returns
-///
-/// Vector of claim transaction IDs. Empty if no claims found or all operators failed.
-async fn get_claims(rpc_manager: &RpcClientManager) -> Vec<Txid> {
-    let result = rpc_manager
-        .query_clients_with_retry(|client| async move {
-            client.get_claims().await.map_err(|e| e.into())
-        })
-        .await;
-
-    result.unwrap_or_else(|| {
-        warn!("no claims found from any operator");
-        Vec::new()
-    })
-}
-
 /// Fetch detailed information for all claim and reimbursement transactions
 ///
 /// Queries bridge operators for claim/reimbursement details, including both new claims
@@ -760,7 +518,7 @@ async fn get_reimbursements(
     chain_tip_height: u64,
     active_reimbursement_txids: &[Txid],
 ) -> Vec<(ReimbursementInfo, u64)> {
-    let new_claims = get_claims(rpc_manager).await;
+    let new_claims = bridge_rpc::get_claims(rpc_manager).await;
     let new_count = new_claims.len();
     let mut claims = new_claims;
 
@@ -781,15 +539,7 @@ async fn get_reimbursements(
     let mut reimbursement_infos = Vec::new();
     for claim_txid in claims.iter() {
         let txid = *claim_txid;
-        let rpc_info = rpc_manager
-            .query_clients_with_retry(|client| async move {
-                match client.get_claim_info(txid).await {
-                    Ok(Some(info)) => Ok(info),
-                    Ok(None) => Err("No claim info found".into()),
-                    Err(e) => Err(e.into()),
-                }
-            })
-            .await;
+        let rpc_info = bridge_rpc::get_claim_info(rpc_manager, txid).await;
 
         let Some(claim_info) = rpc_info else {
             error!(%claim_txid, "failed to fetch claim info after retries");

--- a/backend/crates/bridge/src/status.rs
+++ b/backend/crates/bridge/src/status.rs
@@ -5,14 +5,16 @@ use std::sync::Arc;
 use strata_bridge_rpc::types::{RpcDepositStatus, RpcReimbursementStatus, RpcWithdrawalStatus};
 
 use strata_primitives::buf::Buf32;
+use strata_primitives::L1Height;
 use strata_tasks::ShutdownGuard;
 
 use super::{
     bridge_rpc::{self, RpcClientManager},
     context::BridgeMonitoringContext,
+    esplora,
     types::{
         BridgeStatus, DepositInfo, DepositStatus, OperatorStatus, ReimbursementInfo,
-        ReimbursementStatus, TxStatus, WithdrawalInfo, WithdrawalStatus,
+        ReimbursementStatus, WithdrawalInfo, WithdrawalStatus,
     },
 };
 
@@ -21,37 +23,12 @@ use tracing::{error, info, warn};
 
 use status_config::BridgeMonitoringConfig;
 
-/// Get transaction confirmations from esplora
-async fn get_tx_confirmations(esplora_url: &str, txid: Txid, chain_tip_height: u64) -> Option<u64> {
-    let url = format!("{}/tx/{}/status", esplora_url.trim_end_matches('/'), txid);
-
-    let status_resp = reqwest::get(&url).await;
-
-    let status: TxStatus = match status_resp {
-        Ok(resp) => match resp.json().await {
-            Ok(status) => status,
-            Err(e) => {
-                error!(%txid, error = %e, "failed to parse tx status JSON from esplora");
-                return None;
-            }
-        },
-        Err(e) => {
-            error!(%txid, error = %e, "failed to fetch tx status from esplora");
-            return None;
-        }
-    };
-
-    status
-        .block_height
-        .filter(|_| status.confirmed)
-        .map(|h| chain_tip_height.saturating_sub(h) + 1)
-}
-
 /// Determine which cached deposit entries should be purged
 async fn determine_deposits_to_purge(
     final_deposits: Vec<(Txid, DepositInfo)>,
     config: &BridgeMonitoringConfig,
-    chain_tip_height: u64,
+    esplora_client: &esplora::EsploraClient,
+    chain_tip_height: L1Height,
 ) -> Vec<Txid> {
     let max_confirmations = config.max_tx_confirmations();
     let mut deposits_to_purge = Vec::new();
@@ -66,7 +43,7 @@ async fn determine_deposits_to_purge(
         };
 
         let current_confirmations =
-            get_tx_confirmations(config.esplora_url(), check_txid, chain_tip_height).await;
+            esplora::get_tx_confirmations(esplora_client, check_txid, chain_tip_height).await;
 
         if let Some(confirmations) = current_confirmations {
             if confirmations >= max_confirmations {
@@ -82,7 +59,8 @@ async fn determine_deposits_to_purge(
 async fn determine_withdrawals_to_purge(
     final_withdrawals: Vec<(Buf32, WithdrawalInfo)>,
     config: &BridgeMonitoringConfig,
-    chain_tip_height: u64,
+    esplora_client: &esplora::EsploraClient,
+    chain_tip_height: L1Height,
 ) -> Vec<Buf32> {
     let max_confirmations = config.max_tx_confirmations();
     let mut withdrawals_to_purge = Vec::new();
@@ -90,7 +68,7 @@ async fn determine_withdrawals_to_purge(
     for (request_id, withdrawal_info) in final_withdrawals {
         if let Some(fulfillment_txid) = withdrawal_info.fulfillment_txid {
             let current_confirmations =
-                get_tx_confirmations(config.esplora_url(), fulfillment_txid, chain_tip_height)
+                esplora::get_tx_confirmations(esplora_client, fulfillment_txid, chain_tip_height)
                     .await;
 
             if let Some(confirmations) = current_confirmations {
@@ -108,7 +86,8 @@ async fn determine_withdrawals_to_purge(
 async fn determine_reimbursements_to_purge(
     final_reimbursements: Vec<(Txid, ReimbursementInfo)>,
     config: &BridgeMonitoringConfig,
-    chain_tip_height: u64,
+    esplora_client: &esplora::EsploraClient,
+    chain_tip_height: L1Height,
 ) -> Vec<Txid> {
     let max_confirmations = config.max_tx_confirmations();
     let mut reimbursements_to_purge = Vec::new();
@@ -125,7 +104,7 @@ async fn determine_reimbursements_to_purge(
         };
 
         let current_confirmations =
-            get_tx_confirmations(config.esplora_url(), check_txid, chain_tip_height).await;
+            esplora::get_tx_confirmations(esplora_client, check_txid, chain_tip_height).await;
 
         if let Some(confirmations) = current_confirmations {
             if confirmations >= max_confirmations {
@@ -148,6 +127,10 @@ pub async fn bridge_monitoring_task(
 
     // Create RPC client manager once and reuse it
     let rpc_manager = RpcClientManager::new(context.config());
+    let esplora_client = esplora::EsploraClient::new(
+        context.config().esplora_url(),
+        context.config().esplora_request_timeout_s(),
+    );
 
     loop {
         tokio::select! {
@@ -175,14 +158,13 @@ pub async fn bridge_monitoring_task(
             })
             .await;
 
-        let chain_tip_height =
-            match get_bitcoin_chain_tip_height(context.config().esplora_url()).await {
-                Ok(height) => height,
-                Err(e) => {
-                    error!(error = %e, "failed to get Bitcoin chain tip");
-                    continue;
-                }
-            };
+        let chain_tip_height = match esplora::get_bitcoin_chain_tip_height(&esplora_client).await {
+            Ok(height) => height,
+            Err(e) => {
+                error!(error = %e, "failed to get Bitcoin chain tip");
+                continue;
+            }
+        };
         info!(%chain_tip_height, "bitcoin chain tip");
 
         // Get existing active entries from cache to avoid unnecessary RPC calls
@@ -216,6 +198,7 @@ pub async fn bridge_monitoring_task(
         let deposit_updates: Vec<(Txid, DepositInfo, u64)> = get_deposits(
             &rpc_manager,
             context.config(),
+            &esplora_client,
             chain_tip_height,
             &active_deposits,
         )
@@ -234,8 +217,13 @@ pub async fn bridge_monitoring_task(
                 })
             })
             .await;
-        let deposits_to_purge =
-            determine_deposits_to_purge(final_deposits, context.config(), chain_tip_height).await;
+        let deposits_to_purge = determine_deposits_to_purge(
+            final_deposits,
+            context.config(),
+            &esplora_client,
+            chain_tip_height,
+        )
+        .await;
         context
             .with_state_mut(|cache| {
                 cache.purge_deposits(deposits_to_purge);
@@ -246,6 +234,7 @@ pub async fn bridge_monitoring_task(
         let withdrawal_updates: Vec<(Buf32, WithdrawalInfo, u64)> = get_withdrawals(
             &rpc_manager,
             context.config(),
+            &esplora_client,
             chain_tip_height,
             &active_withdrawals,
         )
@@ -262,9 +251,13 @@ pub async fn bridge_monitoring_task(
                 cache.filter_withdrawals(|s| matches!(s, WithdrawalStatus::Complete))
             })
             .await;
-        let withdrawals_to_purge =
-            determine_withdrawals_to_purge(final_withdrawals, context.config(), chain_tip_height)
-                .await;
+        let withdrawals_to_purge = determine_withdrawals_to_purge(
+            final_withdrawals,
+            context.config(),
+            &esplora_client,
+            chain_tip_height,
+        )
+        .await;
         context
             .with_state_mut(|cache| {
                 cache.purge_withdrawals(withdrawals_to_purge);
@@ -275,6 +268,7 @@ pub async fn bridge_monitoring_task(
         let reimbursement_updates: Vec<(Txid, ReimbursementInfo, u64)> = get_reimbursements(
             &rpc_manager,
             context.config(),
+            &esplora_client,
             chain_tip_height,
             &active_reimbursements,
         )
@@ -299,6 +293,7 @@ pub async fn bridge_monitoring_task(
         let reimbursements_to_purge = determine_reimbursements_to_purge(
             final_reimbursements,
             context.config(),
+            &esplora_client,
             chain_tip_height,
         )
         .await;
@@ -313,18 +308,6 @@ pub async fn bridge_monitoring_task(
     }
 
     Ok(())
-}
-
-/// Fetch bitcoin chain tip height
-async fn get_bitcoin_chain_tip_height(
-    esplora_url: &str,
-) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
-    let endpoint = format!("{}/blocks/tip/height", esplora_url.trim_end_matches('/'));
-    let resp = reqwest::Client::new().get(&endpoint).send().await?;
-
-    let text = resp.text().await?;
-    let height = text.trim().parse::<u64>()?;
-    Ok(height)
 }
 
 /// Fetch detailed information for all deposit requests
@@ -351,7 +334,8 @@ async fn get_bitcoin_chain_tip_height(
 async fn get_deposits(
     rpc_manager: &RpcClientManager,
     config: &BridgeMonitoringConfig,
-    chain_tip_height: u64,
+    esplora_client: &esplora::EsploraClient,
+    chain_tip_height: L1Height,
     active_deposit_txids: &[Txid],
 ) -> Vec<(DepositInfo, u64)> {
     let new_deposit_requests = bridge_rpc::get_deposit_requests(rpc_manager).await;
@@ -396,7 +380,7 @@ async fn get_deposits(
                 };
 
                 let confirmations =
-                    get_tx_confirmations(config.esplora_url(), txid, chain_tip_height).await;
+                    esplora::get_tx_confirmations(esplora_client, txid, chain_tip_height).await;
                 if let Some(confirmations) = confirmations {
                     if confirmations < config.max_tx_confirmations() {
                         deposit_infos.push((DepositInfo::from(&dep_info), confirmations));
@@ -435,7 +419,8 @@ async fn get_deposits(
 async fn get_withdrawals(
     rpc_manager: &RpcClientManager,
     config: &BridgeMonitoringConfig,
-    chain_tip_height: u64,
+    esplora_client: &esplora::EsploraClient,
+    chain_tip_height: L1Height,
     active_withdrawal_request_ids: &[Buf32],
 ) -> Vec<(WithdrawalInfo, u64)> {
     let new_withdrawal_requests = bridge_rpc::get_withdrawal_requests(rpc_manager).await;
@@ -473,9 +458,12 @@ async fn get_withdrawals(
                 withdrawal_infos.push((WithdrawalInfo::from(&wd_info), 0));
             }
             RpcWithdrawalStatus::Complete { fulfillment_txid } => {
-                let confirmations =
-                    get_tx_confirmations(config.esplora_url(), *fulfillment_txid, chain_tip_height)
-                        .await;
+                let confirmations = esplora::get_tx_confirmations(
+                    esplora_client,
+                    *fulfillment_txid,
+                    chain_tip_height,
+                )
+                .await;
                 if let Some(confirmations) = confirmations {
                     if confirmations < config.max_tx_confirmations() {
                         withdrawal_infos.push((WithdrawalInfo::from(&wd_info), confirmations));
@@ -515,7 +503,8 @@ async fn get_withdrawals(
 async fn get_reimbursements(
     rpc_manager: &RpcClientManager,
     config: &BridgeMonitoringConfig,
-    chain_tip_height: u64,
+    esplora_client: &esplora::EsploraClient,
+    chain_tip_height: L1Height,
     active_reimbursement_txids: &[Txid],
 ) -> Vec<(ReimbursementInfo, u64)> {
     let new_claims = bridge_rpc::get_claims(rpc_manager).await;
@@ -566,7 +555,7 @@ async fn get_reimbursements(
                     | RpcReimbursementStatus::Challenged { .. } => unreachable!(), // Already matched
                 };
                 let confirmations =
-                    get_tx_confirmations(config.esplora_url(), txid, chain_tip_height).await;
+                    esplora::get_tx_confirmations(esplora_client, txid, chain_tip_height).await;
                 if let Some(confirmations) = confirmations {
                     if confirmations < config.max_tx_confirmations() {
                         reimbursement_infos

--- a/backend/crates/bridge/src/types.rs
+++ b/backend/crates/bridge/src/types.rs
@@ -28,12 +28,6 @@ impl OperatorStatus {
     }
 }
 
-#[derive(Deserialize)]
-pub(crate) struct TxStatus {
-    pub(crate) confirmed: bool,
-    pub(crate) block_height: Option<u64>,
-}
-
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
 pub(crate) enum DepositStatus {
     #[serde(rename = "In progress")]

--- a/backend/crates/config/src/lib.rs
+++ b/backend/crates/config/src/lib.rs
@@ -44,6 +44,13 @@ impl ApiServerConfig {
 /// Default retry policy base for exponential backoff
 const DEFAULT_RETRY_POLICY_BASE: f64 = 1.5;
 
+/// Default timeout for Esplora HTTP requests in seconds.
+const DEFAULT_ESPLORA_REQUEST_TIMEOUT_S: u64 = 5;
+
+fn default_esplora_request_timeout_s() -> u64 {
+    DEFAULT_ESPLORA_REQUEST_TIMEOUT_S
+}
+
 /// Configuration for network monitoring services
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct NetworkMonitoringConfig {
@@ -107,6 +114,10 @@ impl NetworkMonitoringConfig {
 pub struct BridgeMonitoringConfig {
     /// Esplora URL
     esplora_url: String,
+
+    /// Timeout for Esplora HTTP requests in seconds.
+    #[serde(default = "default_esplora_request_timeout_s")]
+    esplora_request_timeout_s: u64,
 
     /// Maximum confirmations
     max_tx_confirmations: u64,
@@ -226,6 +237,10 @@ impl BridgeMonitoringConfig {
         &self.esplora_url
     }
 
+    pub fn esplora_request_timeout_s(&self) -> u64 {
+        self.esplora_request_timeout_s
+    }
+
     pub fn max_tx_confirmations(&self) -> u64 {
         self.max_tx_confirmations
     }
@@ -316,6 +331,7 @@ retry_policy_total_time_s = 60
 status_refetch_interval_s = 10
 
 [bridge]
+esplora_request_timeout_s = 5
 esplora_url = "https://esplora.testnet.alpenlabs.io"
 max_tx_confirmations = 6
 status_refetch_interval_s = 120
@@ -422,6 +438,7 @@ retry_policy_total_time_s = 30
 status_refetch_interval_s = 5
 
 [bridge]
+esplora_request_timeout_s = 9
 esplora_url = "https://esplora.example.com"
 max_tx_confirmations = 12
 status_refetch_interval_s = 60
@@ -456,6 +473,7 @@ withdrawal_denomination_sats = 100000000
         );
         assert_eq!(config.network.status_refetch_interval(), 5);
         assert_eq!(config.bridge.esplora_url(), "https://esplora.example.com");
+        assert_eq!(config.bridge.esplora_request_timeout_s(), 9);
         assert_eq!(config.bridge.max_tx_confirmations(), 12);
         assert_eq!(config.bridge.status_refetch_interval(), 60);
         assert_eq!(config.bridge.operators().len(), 2);
@@ -490,7 +508,7 @@ withdrawal_denomination_sats = 100000000
     }
 
     #[test]
-    fn test_withdrawal_indexer_defaults() {
+    fn test_monitoring_defaults() {
         let toml_doc = r#"
 datadir = "data"
 
@@ -517,6 +535,10 @@ eth_rpc_url = "https://rpc.example.com"
 "#;
 
         let config = toml::from_str::<Config>(toml_doc).expect("parse");
+        assert_eq!(
+            config.bridge().esplora_request_timeout_s(),
+            DEFAULT_ESPLORA_REQUEST_TIMEOUT_S
+        );
         let indexer = config.withdrawal_indexer();
         assert_eq!(indexer.batch_size(), DEFAULT_ETH_LOGS_BATCH_SIZE);
         assert_eq!(indexer.finality_lag(), DEFAULT_ETH_LOGS_FINALITY_LAG);

--- a/backend/crates/network/src/lib.rs
+++ b/backend/crates/network/src/lib.rs
@@ -1,5 +1,5 @@
 mod status;
 mod types;
 
-pub use status::{fetch_statuses_task, get_network_status};
+pub use status::{get_network_status, network_monitoring_task};
 pub use types::{NetworkMonitoringContext, NetworkStatus};

--- a/backend/crates/network/src/status.rs
+++ b/backend/crates/network/src/status.rs
@@ -68,8 +68,8 @@ async fn check_bundler_health(
     Status::Offline
 }
 
-/// Periodically fetches real statuses
-pub async fn fetch_statuses_task(
+/// Periodically polls configured network service endpoints and updates status state.
+pub async fn network_monitoring_task(
     context: Arc<NetworkMonitoringContext>,
     shutdown: ShutdownGuard,
 ) -> Result<()> {

--- a/backend/example-config.toml
+++ b/backend/example-config.toml
@@ -17,6 +17,7 @@ datadir = "data"
 
 # Bridge monitoring configuration
 [bridge]
+  esplora_request_timeout_s = 5
   esplora_url               = "https://esplora.testnet.alpenlabs.io"
   max_tx_confirmations      = 6
   status_refetch_interval_s = 120
@@ -40,9 +41,9 @@ datadir = "data"
 
 # Withdrawal-intent indexer configuration
 [withdrawal_indexer]
-  eth_rpc_url                  = "https://rpc.testnet.alpenlabs.io"
   batch_size                   = 1_000
+  eth_rpc_url                  = "https://rpc.testnet.alpenlabs.io"
   finality_lag                 = 12
-  start_block                  = 0
   poll_interval_s              = 10
+  start_block                  = 0
   withdrawal_denomination_sats = 100_000_000


### PR DESCRIPTION
## Description

Reorganize the bridge status backend into single-responsibility modules without changing dashboard behavior, cache keys, or the bridge RPC surface.

- **Naming**: rename `fetch_statuses_task` → `network_monitoring_task` so it matches `bridge_monitoring_task`.
- **`bridge_rpc.rs`**: extract `RpcClientManager` + retry/failover and the bridge monitoring RPC call helpers out of `status.rs`.
- **`esplora.rs`**: extract chain-tip and tx-confirmation helpers out of `status.rs`.

`status.rs` now reads as the one-tick polling flow and delegates RPC and Esplora details to their modules.

## Not pure code movement (called out intentionally)

- **Esplora client + timeout**: `esplora.rs` introduces `EsploraClient` with one shared `reqwest::Client` and a configurable `esplora_request_timeout_s` (default 5s). Replaces per-call `reqwest::get` — connection pooling + bounded request latency.
- **Chain heights typed as `L1Height`**: where `main` used bare `u64`. This is the codebase's canonical Bitcoin-height type; the confirmation arithmetic is behavior-equivalent (pinned by a future-height saturation test).

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 