### PR TITLE
STR 3336 Mapping between withdrawal request txid from EVM logs and bridge withdrawals

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 [[package]]
 name = "algebra"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=851a681200658a19d88493a70f3bed66e515a08b#851a681200658a19d88493a70f3bed66e515a08b"
+source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=0ecec67b67db89f6b761ffeaa09af8e7ad864bb1#0ecec67b67db89f6b761ffeaa09af8e7ad864bb1"
 dependencies = [
  "futures",
  "proptest",
@@ -143,7 +143,7 @@ dependencies = [
 [[package]]
 name = "alpen-reth-primitives"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/alpen.git?rev=565fafccf2fe181d2f93003f9135ceed126a01ad#565fafccf2fe181d2f93003f9135ceed126a01ad"
+source = "git+https://github.com/alpenlabs/alpen.git?rev=2c6ae209dd5f2ed71e6f9f7b721ea7ab21190e10#2c6ae209dd5f2ed71e6f9f7b721ea7ab21190e10"
 dependencies = [
  "alloy-sol-types",
  "serde",
@@ -3555,6 +3555,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3916,6 +3925,7 @@ dependencies = [
  "sled",
  "status-config",
  "status-utils",
+ "strata-bridge-primitives",
  "strata-bridge-rpc",
  "strata-primitives",
  "strata-tasks",
@@ -3987,7 +3997,7 @@ checksum = "4af28eeb7c18ac2dbdb255d40bee63f203120e1db6b0024b177746ebec7049c1"
 [[package]]
 name = "strata-asm-common"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=a38db6018a646708f24f115a8b10ff1d74f879c6#a38db6018a646708f24f115a8b10ff1d74f879c6"
+source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
 dependencies = [
  "bitcoin",
  "borsh",
@@ -4014,7 +4024,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-manifest-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=a38db6018a646708f24f115a8b10ff1d74f879c6#a38db6018a646708f24f115a8b10ff1d74f879c6"
+source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
 dependencies = [
  "borsh",
  "serde",
@@ -4035,13 +4045,13 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=a38db6018a646708f24f115a8b10ff1d74f879c6#a38db6018a646708f24f115a8b10ff1d74f879c6"
+source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
 dependencies = [
  "arbitrary",
  "bitcoin",
  "bitcoin-bosd 0.10.0",
  "strata-asm-common",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=a38db6018a646708f24f115a8b10ff1d74f879c6)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42)",
  "strata-btc-types",
  "strata-codec",
  "strata-l1-txfmt",
@@ -4051,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.7#7b271f196f7fefad92c52fb98f1b9bd5b7680495"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
 dependencies = [
  "arbitrary",
  "bitcoin-bosd 0.10.0",
@@ -4068,7 +4078,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=a38db6018a646708f24f115a8b10ff1d74f879c6#a38db6018a646708f24f115a8b10ff1d74f879c6"
+source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
 dependencies = [
  "arbitrary",
  "bitcoin-bosd 0.10.0",
@@ -4085,10 +4095,9 @@ dependencies = [
 [[package]]
 name = "strata-bridge-connectors"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=851a681200658a19d88493a70f3bed66e515a08b#851a681200658a19d88493a70f3bed66e515a08b"
+source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=0ecec67b67db89f6b761ffeaa09af8e7ad864bb1#0ecec67b67db89f6b761ffeaa09af8e7ad864bb1"
 dependencies = [
  "bitcoin",
- "bitcoin-bosd 0.10.0",
  "secp256k1",
  "serde",
  "strata-bridge-primitives",
@@ -4098,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "strata-bridge-p2p-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=851a681200658a19d88493a70f3bed66e515a08b#851a681200658a19d88493a70f3bed66e515a08b"
+source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=0ecec67b67db89f6b761ffeaa09af8e7ad864bb1#0ecec67b67db89f6b761ffeaa09af8e7ad864bb1"
 dependencies = [
  "bitcoin",
  "bitcoin-bosd 0.10.0",
@@ -4114,7 +4123,7 @@ dependencies = [
 [[package]]
 name = "strata-bridge-primitives"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=851a681200658a19d88493a70f3bed66e515a08b#851a681200658a19d88493a70f3bed66e515a08b"
+source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=0ecec67b67db89f6b761ffeaa09af8e7ad864bb1#0ecec67b67db89f6b761ffeaa09af8e7ad864bb1"
 dependencies = [
  "algebra",
  "anyhow",
@@ -4137,13 +4146,13 @@ dependencies = [
  "strata-predicate",
  "thiserror 2.0.18",
  "tokio",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc24)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
 ]
 
 [[package]]
 name = "strata-bridge-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=851a681200658a19d88493a70f3bed66e515a08b#851a681200658a19d88493a70f3bed66e515a08b"
+source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=0ecec67b67db89f6b761ffeaa09af8e7ad864bb1#0ecec67b67db89f6b761ffeaa09af8e7ad864bb1"
 dependencies = [
  "bitcoin",
  "jsonrpsee",
@@ -4158,12 +4167,13 @@ dependencies = [
 [[package]]
 name = "strata-bridge-sm"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=851a681200658a19d88493a70f3bed66e515a08b#851a681200658a19d88493a70f3bed66e515a08b"
+source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=0ecec67b67db89f6b761ffeaa09af8e7ad864bb1#0ecec67b67db89f6b761ffeaa09af8e7ad864bb1"
 dependencies = [
  "bitcoin",
  "bitcoin-bosd 0.10.0",
  "musig2 0.1.1 (git+https://github.com/alpenlabs/musig2?branch=fix%2Fdeserialization-mismatch)",
  "serde",
+ "serde-big-array",
  "strata-asm-common",
  "strata-asm-proto-bridge-v1-txs",
  "strata-bridge-connectors",
@@ -4175,13 +4185,13 @@ dependencies = [
  "strata-predicate",
  "thiserror 2.0.18",
  "tracing",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc24)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
 ]
 
 [[package]]
 name = "strata-bridge-tx-graph"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=851a681200658a19d88493a70f3bed66e515a08b#851a681200658a19d88493a70f3bed66e515a08b"
+source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=0ecec67b67db89f6b761ffeaa09af8e7ad864bb1#0ecec67b67db89f6b761ffeaa09af8e7ad864bb1"
 dependencies = [
  "algebra",
  "bitcoin",
@@ -4193,12 +4203,13 @@ dependencies = [
  "strata-bridge-connectors",
  "strata-bridge-primitives",
  "strata-l1-txfmt",
+ "tracing",
 ]
 
 [[package]]
 name = "strata-btc-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc19#f24dc6483e9134dacf22a5fcb7481183282068f2"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -4218,7 +4229,7 @@ dependencies = [
 [[package]]
 name = "strata-btc-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=a38db6018a646708f24f115a8b10ff1d74f879c6#a38db6018a646708f24f115a8b10ff1d74f879c6"
+source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -4235,7 +4246,7 @@ dependencies = [
 [[package]]
 name = "strata-codec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc19#f24dc6483e9134dacf22a5fcb7481183282068f2"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
 dependencies = [
  "strata-codec-derive",
  "thiserror 2.0.18",
@@ -4244,7 +4255,7 @@ dependencies = [
 [[package]]
 name = "strata-codec-derive"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc19#f24dc6483e9134dacf22a5fcb7481183282068f2"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -4253,7 +4264,7 @@ dependencies = [
 [[package]]
 name = "strata-crypto"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc19#f24dc6483e9134dacf22a5fcb7481183282068f2"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -4273,7 +4284,7 @@ dependencies = [
 [[package]]
 name = "strata-identifiers"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc19#f24dc6483e9134dacf22a5fcb7481183282068f2"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -4294,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-txfmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc19#f24dc6483e9134dacf22a5fcb7481183282068f2"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -4306,7 +4317,7 @@ dependencies = [
 [[package]]
 name = "strata-merkle"
 version = "0.2.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc19#f24dc6483e9134dacf22a5fcb7481183282068f2"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -4326,7 +4337,7 @@ dependencies = [
 [[package]]
 name = "strata-mosaic-client-api"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=851a681200658a19d88493a70f3bed66e515a08b#851a681200658a19d88493a70f3bed66e515a08b"
+source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=0ecec67b67db89f6b761ffeaa09af8e7ad864bb1#0ecec67b67db89f6b761ffeaa09af8e7ad864bb1"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -4338,7 +4349,7 @@ dependencies = [
 [[package]]
 name = "strata-msg-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc19#f24dc6483e9134dacf22a5fcb7481183282068f2"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -4346,14 +4357,14 @@ dependencies = [
 [[package]]
 name = "strata-ol-bridge-types"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/alpen.git?rev=565fafccf2fe181d2f93003f9135ceed126a01ad#565fafccf2fe181d2f93003f9135ceed126a01ad"
+source = "git+https://github.com/alpenlabs/alpen.git?rev=2c6ae209dd5f2ed71e6f9f7b721ea7ab21190e10#2c6ae209dd5f2ed71e6f9f7b721ea7ab21190e10"
 dependencies = [
  "arbitrary",
  "borsh",
  "serde",
  "ssz",
  "ssz_derive",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.7)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8)",
  "strata-codec",
  "strata-identifiers",
  "strata-primitives",
@@ -4363,7 +4374,7 @@ dependencies = [
 [[package]]
 name = "strata-predicate"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc19#f24dc6483e9134dacf22a5fcb7481183282068f2"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
 dependencies = [
  "borsh",
  "hex",
@@ -4384,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "strata-primitives"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/alpen.git?rev=565fafccf2fe181d2f93003f9135ceed126a01ad#565fafccf2fe181d2f93003f9135ceed126a01ad"
+source = "git+https://github.com/alpenlabs/alpen.git?rev=2c6ae209dd5f2ed71e6f9f7b721ea7ab21190e10#2c6ae209dd5f2ed71e6f9f7b721ea7ab21190e10"
 dependencies = [
  "bitcoin",
  "bitcoin-bosd 0.10.0",
@@ -5649,10 +5660,8 @@ dependencies = [
 [[package]]
 name = "zkaleido"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc20#d5b46312a55e8409a08a8437716ca42128e3d085"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.1#d24c4ce44e4ff2abd4328a5adb373ffb79f34c8c"
 dependencies = [
- "arbitrary",
- "async-trait",
  "bincode",
  "borsh",
  "serde",
@@ -5662,7 +5671,7 @@ dependencies = [
 [[package]]
 name = "zkaleido"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc24#69692581a5e1cb5a361fb6a3a23d847fd93a6b47"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2#c2683cf676490decc045d9a91d6c8b5740138f1c"
 dependencies = [
  "bincode",
  "borsh",
@@ -5673,7 +5682,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-logging"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc24#69692581a5e1cb5a361fb6a3a23d847fd93a6b47"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2#c2683cf676490decc045d9a91d6c8b5740138f1c"
 dependencies = [
  "tracing",
 ]
@@ -5681,7 +5690,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-sp1-groth16-verifier"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc20#d5b46312a55e8409a08a8437716ca42128e3d085"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.1#d24c4ce44e4ff2abd4328a5adb373ffb79f34c8c"
 dependencies = [
  "blake3",
  "borsh",
@@ -5690,7 +5699,7 @@ dependencies = [
  "sha2",
  "substrate-bn",
  "thiserror 1.0.69",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1.0-alpha-rc20)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.1)",
 ]
 
 [[package]]

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3976,6 +3976,7 @@ dependencies = [
  "status-utils",
  "strata-tasks",
  "tokio",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
 ]
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -19,14 +19,14 @@
     status-network = { path = "crates/network" }
     status-utils   = { path = "crates/utils" }
 
-    # alpen pinned to the rev that strata-bridge HEAD uses, so the transitive
-    # `strata-primitives`/`Buf32` matches our direct pin (no double-resolution).
-    # Both are deploy-current as of 2026-04-30.
-    alpen-reth-primitives = { git = "https://github.com/alpenlabs/alpen.git", rev = "565fafccf2fe181d2f93003f9135ceed126a01ad" }
+    # alpen pinned to the rev referenced by the chosen strata-bridge revision,
+    # so the transitive `strata-primitives`/`Buf32` matches our direct pin.
+    alpen-reth-primitives = { git = "https://github.com/alpenlabs/alpen.git", rev = "2c6ae209dd5f2ed71e6f9f7b721ea7ab21190e10" }
+    strata-bridge-primitives = { git = "https://github.com/alpenlabs/strata-bridge.git", rev = "0ecec67b67db89f6b761ffeaa09af8e7ad864bb1" }
     strata-bridge-rpc = { git = "https://github.com/alpenlabs/strata-bridge.git", features = [
       "client",
-    ], rev = "851a681200658a19d88493a70f3bed66e515a08b" }
-    strata-primitives = { git = "https://github.com/alpenlabs/alpen.git", rev = "565fafccf2fe181d2f93003f9135ceed126a01ad" }
+    ], rev = "0ecec67b67db89f6b761ffeaa09af8e7ad864bb1" }
+    strata-primitives = { git = "https://github.com/alpenlabs/alpen.git", rev = "2c6ae209dd5f2ed71e6f9f7b721ea7ab21190e10" }
     strata-tasks = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc16" }
     typed-sled = { git = "https://github.com/alpenlabs/typed-sled" }
 

--- a/backend/bin/dashboard/src/main.rs
+++ b/backend/bin/dashboard/src/main.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use axum::{routing::get, Router};
 use status_bridge::{
     bridge_monitoring_task, get_bridge_status, run_withdrawal_indexer, BridgeMonitoringContext,
+    WithdrawalIndexerDbSled,
 };
 use status_config::Config;
 use status_network::{get_network_status, network_monitoring_task, NetworkMonitoringContext};
@@ -30,8 +31,12 @@ fn main() -> Result<()> {
     let task_manager = TaskManager::new(runtime.handle().clone());
     let executor = task_manager.create_executor();
 
+    let withdrawal_index_db = Arc::new(WithdrawalIndexerDbSled::open(config.datadir())?);
     let network_context = Arc::new(NetworkMonitoringContext::new(config.network().clone()));
-    let bridge_context = Arc::new(BridgeMonitoringContext::new(config.bridge().clone()));
+    let bridge_context = Arc::new(BridgeMonitoringContext::new(
+        config.bridge().clone(),
+        Arc::clone(&withdrawal_index_db),
+    ));
 
     let cors = CorsLayer::new().allow_origin(Any);
     let app = Router::new()
@@ -61,15 +66,15 @@ fn main() -> Result<()> {
         move |shutdown| async move { network_monitoring_task(network_context, shutdown).await }
     });
 
+    executor.spawn_critical_async_with_shutdown("withdrawal-indexer", {
+        let withdrawal_index_db = Arc::clone(&withdrawal_index_db);
+        let cfg = config.withdrawal_indexer().clone();
+        move |shutdown| async move { run_withdrawal_indexer(withdrawal_index_db, cfg, shutdown).await }
+    });
+
     executor.spawn_critical_async_with_shutdown("bridge-monitoring", {
         let bridge_context = Arc::clone(&bridge_context);
         move |shutdown| async move { bridge_monitoring_task(bridge_context, shutdown).await }
-    });
-
-    executor.spawn_critical_async_with_shutdown("withdrawal-indexer", {
-        let datadir = config.datadir().to_path_buf();
-        let cfg = config.withdrawal_indexer().clone();
-        move |shutdown| async move { run_withdrawal_indexer(&datadir, cfg, shutdown).await }
     });
 
     executor.spawn_critical_async_with_shutdown("http-server", {

--- a/backend/crates/bridge/Cargo.toml
+++ b/backend/crates/bridge/Cargo.toml
@@ -7,14 +7,15 @@
   path = "src/lib.rs"
 
 [dependencies]
-  alpen-reth-primitives.workspace = true
-  anyhow.workspace                = true
-  status-config.workspace         = true
-  status-utils.workspace          = true
-  strata-bridge-rpc.workspace     = true
-  strata-primitives.workspace     = true
-  strata-tasks.workspace          = true
-  typed-sled.workspace            = true
+  alpen-reth-primitives.workspace    = true
+  anyhow.workspace                   = true
+  status-config.workspace            = true
+  status-utils.workspace             = true
+  strata-bridge-primitives.workspace = true
+  strata-bridge-rpc.workspace        = true
+  strata-primitives.workspace        = true
+  strata-tasks.workspace             = true
+  typed-sled.workspace               = true
 
   alloy-primitives.workspace = true
   alloy-sol-types.workspace  = true

--- a/backend/crates/bridge/src/bridge_rpc.rs
+++ b/backend/crates/bridge/src/bridge_rpc.rs
@@ -3,7 +3,9 @@ use jsonrpsee::http_client::HttpClient;
 use std::collections::BTreeMap;
 use strata_bridge_primitives::types::DepositIdx;
 use strata_bridge_rpc::traits::{StrataBridgeControlApiClient, StrataBridgeMonitoringApiClient};
-use strata_bridge_rpc::types::{RpcDepositInfo, RpcOperatorStatus, RpcReimbursementStatus};
+use strata_bridge_rpc::types::{
+    RpcDepositInfo, RpcOperatorStatus, RpcReimbursementStatus, RpcWithdrawalStatus,
+};
 use tracing::{debug, warn};
 
 use status_config::BridgeMonitoringConfig;
@@ -198,6 +200,22 @@ pub(crate) async fn get_deposit_info(
         })
         .await
         .ok_or_else(|| anyhow!("failed to fetch deposit info for deposit_idx {deposit_idx}"))
+}
+
+/// Fetch withdrawal status by bridge-side deposit index.
+pub(crate) async fn get_withdrawal_status(
+    rpc_manager: &RpcClientManager,
+    deposit_idx: DepositIdx,
+) -> Result<Option<RpcWithdrawalStatus>> {
+    rpc_manager
+        .query_clients_with_retry(|client| async move {
+            client
+                .get_withdrawal_status(deposit_idx)
+                .await
+                .map_err(|e| e.into())
+        })
+        .await
+        .ok_or_else(|| anyhow!("failed to fetch withdrawal status for deposit_idx {deposit_idx}"))
 }
 
 /// Fetch reimbursement status by bridge-side deposit index.

--- a/backend/crates/bridge/src/bridge_rpc.rs
+++ b/backend/crates/bridge/src/bridge_rpc.rs
@@ -9,37 +9,38 @@ use tracing::{debug, warn};
 use status_config::BridgeMonitoringConfig;
 use status_utils::{create_rpc_client, execute_with_retries};
 
-/// RPC client manager with connection pooling and retry logic
+/// RPC client manager with connection pooling and retry logic.
 ///
-/// This manager maintains a pool of reusable HTTP clients for each bridge operator,
+/// This manager maintains a pool of reusable HTTP clients for each bridge RPC endpoint,
 /// preventing connection exhaustion by reusing clients across requests. It implements
 /// automatic retry logic with exponential backoff to handle transient network failures.
 ///
 /// # Design
 ///
-/// - **Connection Pooling**: Creates one HTTP client per operator and reuses it for all requests
+/// - **Connection Pooling**: Creates one HTTP client per configured endpoint and reuses it
 /// - **Retry Logic**: Implements exponential backoff (3 retries over 10 seconds with 1.5x multiplier)
-/// - **Failover**: Tries all available operators in deterministic order (sorted by public key)
-/// - **Graceful Degradation**: Returns `None` if all operators fail after retries
+/// - **Failover**: Tries all available clients in deterministic key order
+/// - **Graceful Degradation**: Returns `None` if all clients fail after retries
 ///
 /// # Example Flow
 ///
 /// For each RPC request:
 ///
-/// 1. Try operator 1 with up to 3 retries (exponential backoff between retries)
-/// 2. If operator 1 fails after retries, try operator 2 with up to 3 retries
-/// 3. Continue until an operator succeeds or all fail
+/// 1. Try client 1 with up to 3 retries (exponential backoff between retries)
+/// 2. If client 1 fails after retries, try client 2 with up to 3 retries
+/// 3. Continue until a client succeeds or all fail
 /// 4. Return the first successful result or [`None`] if all fail
 pub(crate) struct RpcClientManager {
-    /// HTTP clients for each operator, keyed by operator public key ([`String`])
-    /// [`BTreeMap`] ensures deterministic ordering (sorted by key)
+    /// HTTP clients keyed by configured client key.
+    ///
+    /// [`BTreeMap`] ensures deterministic ordering.
     clients: BTreeMap<String, HttpClient>,
 }
 
 impl RpcClientManager {
-    /// Create a new RPC client manager for the configured bridge operators
+    /// Create a new RPC client manager for the configured bridge RPC endpoints.
     ///
-    /// This initializes one HTTP client per operator with:
+    /// This initializes one HTTP client per configured endpoint with:
     ///
     /// - 30-second request timeout
     /// - 10MB max request size
@@ -47,7 +48,7 @@ impl RpcClientManager {
     ///
     /// # Arguments
     ///
-    /// * `config` - Bridge monitoring configuration containing operator RPC URLs
+    /// * `config` - Bridge monitoring configuration containing RPC endpoints
     pub(crate) fn new(config: &BridgeMonitoringConfig) -> Self {
         let mut clients = BTreeMap::new();
         for operator in config.operators() {
@@ -62,8 +63,8 @@ impl RpcClientManager {
 
     /// Execute an async operation across all available clients with retry logic
     ///
-    /// This method tries the given operation on each operator sequentially (in sorted order
-    /// by public key). For each operator, it retries up to 3 times with exponential
+    /// This method tries the given operation on each client sequentially in sorted key
+    /// order. For each client, it retries up to 3 times with exponential
     /// backoff between attempts using [`execute_with_retries`]. The first successful result
     /// is returned immediately.
     ///
@@ -79,18 +80,18 @@ impl RpcClientManager {
     ///
     /// # Returns
     ///
-    /// * [`Some(T)`](Some) - If any operator succeeds (possibly after retries)
-    /// * [`None`] - If all operators fail after exhausting their retries
+    /// * [`Some(T)`](Some) - If any client succeeds (possibly after retries)
+    /// * [`None`] - If all clients fail after exhausting their retries
     ///
     /// # Retry Behavior
     ///
-    /// Uses [`execute_with_retries`] for each operator with exponential backoff:
+    /// Uses [`execute_with_retries`] for each client with exponential backoff:
     ///
     /// - **Attempt 0**: Immediate (no delay)
     /// - **Attempt 1**: After ~2s delay
     /// - **Attempt 2**: After ~3s delay
     /// - **Attempt 3**: After ~5s delay
-    /// - Total: ~10 seconds per operator
+    /// - Total: ~10 seconds per client
     ///
     /// # Example
     ///
@@ -106,10 +107,10 @@ impl RpcClientManager {
         F: Fn(HttpClient) -> Fut,
         Fut: std::future::Future<Output = Result<T, Box<dyn std::error::Error + Send + Sync>>>,
     {
-        // BTreeMap maintains sorted order automatically
-        for (key, client) in self.clients.iter() {
+        // BTreeMap maintains sorted order automatically.
+        for (client_key, client) in self.clients.iter() {
             let client_clone = client.clone();
-            let operation_name = format!("RPC request to operator public key {key}");
+            let operation_name = format!("RPC request to bridge client {client_key}");
 
             match execute_with_retries(
                 || {
@@ -121,34 +122,52 @@ impl RpcClientManager {
             .await
             {
                 Ok(result) => {
-                    debug!(operator_pk = %key, "rpc request succeeded");
+                    debug!(client_key = %client_key, "rpc request succeeded");
                     return Some(result);
                 }
                 Err(e) => {
                     warn!(
-                        operator_pk = %key,
+                        client_key = %client_key,
                         error = %e,
                         "rpc request failed after retries"
                     );
-                    // Continue to next operator
+                    // Continue to next client.
                 }
             }
         }
 
         None
     }
+
+    /// Return the pooled client for a configured client key.
+    pub(crate) fn client(&self, client_key: &str) -> Option<&HttpClient> {
+        self.clients.get(client_key)
+    }
 }
 
 /// Fetch operator status.
-pub(crate) async fn get_operator_status(rpc_url: &str) -> RpcOperatorStatus {
-    let rpc_client = create_rpc_client(rpc_url);
+pub(crate) async fn get_operator_status(
+    rpc_manager: &RpcClientManager,
+    operator_public_key: &str,
+) -> RpcOperatorStatus {
+    let Some(client) = rpc_manager.client(operator_public_key) else {
+        warn!(
+            operator_pk = %operator_public_key,
+            "missing bridge operator RPC client"
+        );
+        return RpcOperatorStatus::Offline;
+    };
 
-    // Directly use `get_uptime`
-    if rpc_client.get_uptime().await.is_ok() {
-        RpcOperatorStatus::Online
-    } else {
-        warn!("failed to fetch bridge operator uptime");
-        RpcOperatorStatus::Offline
+    match client.get_uptime().await {
+        Ok(_) => RpcOperatorStatus::Online,
+        Err(e) => {
+            warn!(
+                operator_pk = %operator_public_key,
+                error = %e,
+                "failed to fetch bridge operator uptime"
+            );
+            RpcOperatorStatus::Offline
+        }
     }
 }
 

--- a/backend/crates/bridge/src/bridge_rpc.rs
+++ b/backend/crates/bridge/src/bridge_rpc.rs
@@ -1,12 +1,9 @@
-use anyhow::Result;
-use bitcoin::Txid;
+use anyhow::{anyhow, Result};
 use jsonrpsee::http_client::HttpClient;
 use std::collections::BTreeMap;
+use strata_bridge_primitives::types::DepositIdx;
 use strata_bridge_rpc::traits::{StrataBridgeControlApiClient, StrataBridgeMonitoringApiClient};
-use strata_bridge_rpc::types::{
-    RpcClaimInfo, RpcDepositInfo, RpcOperatorStatus, RpcWithdrawalInfo,
-};
-use strata_primitives::buf::Buf32;
+use strata_bridge_rpc::types::{RpcDepositInfo, RpcOperatorStatus, RpcReimbursementStatus};
 use tracing::{debug, warn};
 
 use status_config::BridgeMonitoringConfig;
@@ -100,7 +97,7 @@ impl RpcClientManager {
     /// ```ignore
     /// let result = rpc_manager
     ///     .query_clients_with_retry(|client| async move {
-    ///         client.get_deposit_requests().await.map_err(|e| e.into())
+    ///         client.get_deposit_indices().await.map_err(|e| e.into())
     ///     })
     ///     .await;
     /// ```
@@ -155,127 +152,49 @@ pub(crate) async fn get_operator_status(rpc_url: &str) -> RpcOperatorStatus {
     }
 }
 
-/// Fetch all pending deposit request transaction IDs from bridge operators.
+/// Fetch all known deposit indices from bridge operators.
 ///
-/// Uses the RPC client manager with retry logic to query all operators for their
-/// list of deposit requests. Returns the first non-empty result, or an empty vector
-/// if all operators have no deposits or all fail.
-///
-/// # Arguments
-///
-/// * `rpc_manager` - RPC client manager with retry/failover logic
-///
-/// # Returns
-///
-/// Vector of deposit request transaction IDs. Empty if no deposits found or all operators failed.
-pub(crate) async fn get_deposit_requests(rpc_manager: &RpcClientManager) -> Vec<Txid> {
-    let result = rpc_manager
+/// Uses the RPC client manager with retry logic to query operators for the
+/// bridge's durable deposit index set.
+pub(crate) async fn get_deposit_indices(rpc_manager: &RpcClientManager) -> Result<Vec<DepositIdx>> {
+    rpc_manager
         .query_clients_with_retry(|client| async move {
-            client.get_deposit_requests().await.map_err(|e| e.into())
+            client.get_deposit_indices().await.map_err(|e| e.into())
         })
-        .await;
-
-    result.unwrap_or_else(|| {
-        warn!("no deposit requests found from any operator");
-        Vec::new()
-    })
+        .await
+        .ok_or_else(|| anyhow!("failed to fetch deposit indices after retries"))
 }
 
-/// Fetch deposit request information from bridge operators.
-pub(crate) async fn get_deposit_request_info(
+/// Fetch deposit details by bridge-side deposit index.
+pub(crate) async fn get_deposit_info(
     rpc_manager: &RpcClientManager,
-    txid: Txid,
-) -> Option<RpcDepositInfo> {
+    deposit_idx: DepositIdx,
+) -> Result<RpcDepositInfo> {
     rpc_manager
         .query_clients_with_retry(|client| async move {
             client
-                .get_deposit_request_info(txid)
+                .get_deposit_info(deposit_idx)
                 .await
                 .map_err(|e| e.into())
         })
         .await
+        .ok_or_else(|| anyhow!("failed to fetch deposit info for deposit_idx {deposit_idx}"))
 }
 
-/// Fetch all pending withdrawal request IDs from bridge operators.
-///
-/// Uses the RPC client manager with retry logic to query all operators for their
-/// list of withdrawal requests. Returns the first non-empty result, or an empty vector
-/// if all operators have no withdrawals or all fail.
-///
-/// # Arguments
-///
-/// * `rpc_manager` - RPC client manager with retry/failover logic
-///
-/// # Returns
-///
-/// Vector of withdrawal request IDs. Empty if no withdrawals found or all operators failed.
-pub(crate) async fn get_withdrawal_requests(rpc_manager: &RpcClientManager) -> Vec<Buf32> {
-    let result = rpc_manager
-        .query_clients_with_retry(|client| async move {
-            client.get_withdrawals().await.map_err(|e| e.into())
-        })
-        .await;
-
-    result.unwrap_or_else(|| {
-        warn!("no withdrawal requests found from any operator");
-        Vec::new()
-    })
-}
-
-/// Fetch withdrawal information from bridge operators.
-pub(crate) async fn get_withdrawal_info(
+/// Fetch reimbursement status by bridge-side deposit index.
+pub(crate) async fn get_reimbursement_status(
     rpc_manager: &RpcClientManager,
-    request_id: Buf32,
-) -> Option<RpcWithdrawalInfo> {
+    deposit_idx: DepositIdx,
+) -> Result<Option<RpcReimbursementStatus>> {
     rpc_manager
         .query_clients_with_retry(|client| async move {
-            match client.get_withdrawal_info(request_id).await {
-                Ok(Some(info)) => Ok(info),
-                Ok(None) => Err("No withdrawal info found".into()),
-                Err(e) => Err(e.into()),
-            }
+            client
+                .get_reimbursement_status(deposit_idx)
+                .await
+                .map_err(|e| e.into())
         })
         .await
-}
-
-/// Fetch all pending claim transaction IDs from bridge operators.
-///
-/// Uses the RPC client manager with retry logic to query all operators for their
-/// list of claim transactions. Returns the first non-empty result, or an empty vector
-/// if all operators have no claims or all fail.
-///
-/// # Arguments
-///
-/// * `rpc_manager` - RPC client manager with retry/failover logic
-///
-/// # Returns
-///
-/// Vector of claim transaction IDs. Empty if no claims found or all operators failed.
-pub(crate) async fn get_claims(rpc_manager: &RpcClientManager) -> Vec<Txid> {
-    let result = rpc_manager
-        .query_clients_with_retry(|client| async move {
-            client.get_claims().await.map_err(|e| e.into())
+        .ok_or_else(|| {
+            anyhow!("failed to fetch reimbursement status for deposit_idx {deposit_idx}")
         })
-        .await;
-
-    result.unwrap_or_else(|| {
-        warn!("no claims found from any operator");
-        Vec::new()
-    })
-}
-
-/// Fetch claim information from bridge operators.
-pub(crate) async fn get_claim_info(
-    rpc_manager: &RpcClientManager,
-    txid: Txid,
-) -> Option<RpcClaimInfo> {
-    rpc_manager
-        .query_clients_with_retry(|client| async move {
-            match client.get_claim_info(txid).await {
-                Ok(Some(info)) => Ok(info),
-                Ok(None) => Err("No claim info found".into()),
-                Err(e) => Err(e.into()),
-            }
-        })
-        .await
 }

--- a/backend/crates/bridge/src/cache.rs
+++ b/backend/crates/bridge/src/cache.rs
@@ -1,7 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 use std::time::{SystemTime, UNIX_EPOCH};
 use strata_bridge_primitives::types::DepositIdx;
-use strata_primitives::buf::Buf32;
 
 use super::types::{
     DepositInfo, DepositStatus, OperatorStatus, ReimbursementInfo, ReimbursementStatus,
@@ -53,13 +52,20 @@ pub(crate) struct WithdrawalPairing {
     cursor: WithdrawalPairingCursor,
 }
 
+/// In-memory cursor for bridge withdrawal status polling progress.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct WithdrawalStatusCursor {
+    pub(crate) next_deposit_idx: DepositIdx,
+}
+
 /// In-memory cache for bridge monitoring data
 #[derive(Debug, Default, Clone)]
 pub(crate) struct BridgeStatusCache {
     deposits: HashMap<DepositIdx, CacheEntry<DepositInfo>>,
     deposit_info_cursor: DepositIdx,
     withdrawal_pairing: WithdrawalPairing,
-    withdrawals: HashMap<Buf32, CacheEntry<WithdrawalInfo>>,
+    withdrawal_status_cursor: WithdrawalStatusCursor,
+    withdrawals: HashMap<DepositIdx, CacheEntry<WithdrawalInfo>>,
     reimbursements: HashMap<DepositIdx, CacheEntry<ReimbursementInfo>>,
     operators: Vec<OperatorStatus>,
 }
@@ -77,10 +83,6 @@ impl BridgeStatusCache {
         self.withdrawal_pairing.cursor
     }
 
-    #[expect(
-        dead_code,
-        reason = "used when withdrawal status candidates are selected in the next commit"
-    )]
     pub(crate) fn withdrawal_pairings_from(
         &self,
         deposit_idx: DepositIdx,
@@ -103,6 +105,14 @@ impl BridgeStatusCache {
         self.withdrawal_pairing.cursor = cursor;
     }
 
+    pub(crate) fn withdrawal_status_cursor(&self) -> WithdrawalStatusCursor {
+        self.withdrawal_status_cursor
+    }
+
+    pub(crate) fn set_withdrawal_status_cursor(&mut self, cursor: WithdrawalStatusCursor) {
+        self.withdrawal_status_cursor = cursor;
+    }
+
     /// Update deposit cache entry
     pub(crate) fn update_deposit(
         &mut self,
@@ -121,15 +131,15 @@ impl BridgeStatusCache {
     /// Update withdrawal cache entry
     pub(crate) fn update_withdrawal(
         &mut self,
-        request_id: Buf32,
+        deposit_idx: DepositIdx,
         info: WithdrawalInfo,
         confirmations: u64,
     ) {
-        if let Some(entry) = self.withdrawals.get_mut(&request_id) {
+        if let Some(entry) = self.withdrawals.get_mut(&deposit_idx) {
             entry.update(info, confirmations);
         } else {
             self.withdrawals
-                .insert(request_id, CacheEntry::new(info, confirmations));
+                .insert(deposit_idx, CacheEntry::new(info, confirmations));
         }
     }
 
@@ -166,9 +176,12 @@ impl BridgeStatusCache {
     }
 
     /// Batch update withdrawals
-    pub(crate) fn apply_withdrawal_updates(&mut self, updates: Vec<(Buf32, WithdrawalInfo, u64)>) {
-        for (request_id, info, confirmations) in updates {
-            self.update_withdrawal(request_id, info, confirmations);
+    pub(crate) fn apply_withdrawal_updates(
+        &mut self,
+        updates: Vec<(DepositIdx, WithdrawalInfo, u64)>,
+    ) {
+        for (deposit_idx, info, confirmations) in updates {
+            self.update_withdrawal(deposit_idx, info, confirmations);
         }
     }
 
@@ -195,14 +208,14 @@ impl BridgeStatusCache {
     }
 
     /// Filter withdrawals based on status condition
-    pub(crate) fn filter_withdrawals<F>(&self, filter: F) -> Vec<(Buf32, WithdrawalInfo)>
+    pub(crate) fn filter_withdrawals<F>(&self, filter: F) -> Vec<(DepositIdx, WithdrawalInfo)>
     where
         F: Fn(&WithdrawalStatus) -> bool,
     {
         self.withdrawals
             .iter()
             .filter(|(_, entry)| filter(&entry.data.status))
-            .map(|(request_id, entry)| (*request_id, entry.data))
+            .map(|(deposit_idx, entry)| (*deposit_idx, entry.data))
             .collect()
     }
 
@@ -226,13 +239,9 @@ impl BridgeStatusCache {
     }
 
     /// Purge specific withdrawal entries
-    #[expect(
-        dead_code,
-        reason = "withdrawal purge resumes when deposit-index pairing is wired in the next commit"
-    )]
-    pub(crate) fn purge_withdrawals(&mut self, withdrawals_to_purge: Vec<Buf32>) {
-        for request_id in withdrawals_to_purge {
-            self.withdrawals.remove(&request_id);
+    pub(crate) fn purge_withdrawals(&mut self, withdrawals_to_purge: Vec<DepositIdx>) {
+        for deposit_idx in withdrawals_to_purge {
+            self.withdrawals.remove(&deposit_idx);
         }
     }
 

--- a/backend/crates/bridge/src/cache.rs
+++ b/backend/crates/bridge/src/cache.rs
@@ -58,6 +58,12 @@ pub(crate) struct WithdrawalStatusCursor {
     pub(crate) next_deposit_idx: DepositIdx,
 }
 
+/// In-memory cursor for bridge reimbursement status polling progress.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct ReimbursementStatusCursor {
+    pub(crate) next_deposit_idx: DepositIdx,
+}
+
 /// In-memory cache for bridge monitoring data
 #[derive(Debug, Default, Clone)]
 pub(crate) struct BridgeStatusCache {
@@ -66,6 +72,7 @@ pub(crate) struct BridgeStatusCache {
     withdrawal_pairing: WithdrawalPairing,
     withdrawal_status_cursor: WithdrawalStatusCursor,
     withdrawals: HashMap<DepositIdx, CacheEntry<WithdrawalInfo>>,
+    reimbursement_status_cursor: ReimbursementStatusCursor,
     reimbursements: HashMap<DepositIdx, CacheEntry<ReimbursementInfo>>,
     operators: Vec<OperatorStatus>,
 }
@@ -111,6 +118,14 @@ impl BridgeStatusCache {
 
     pub(crate) fn set_withdrawal_status_cursor(&mut self, cursor: WithdrawalStatusCursor) {
         self.withdrawal_status_cursor = cursor;
+    }
+
+    pub(crate) fn reimbursement_status_cursor(&self) -> ReimbursementStatusCursor {
+        self.reimbursement_status_cursor
+    }
+
+    pub(crate) fn set_reimbursement_status_cursor(&mut self, cursor: ReimbursementStatusCursor) {
+        self.reimbursement_status_cursor = cursor;
     }
 
     /// Update deposit cache entry

--- a/backend/crates/bridge/src/cache.rs
+++ b/backend/crates/bridge/src/cache.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::time::{SystemTime, UNIX_EPOCH};
 use strata_bridge_primitives::types::DepositIdx;
 use strata_primitives::buf::Buf32;
@@ -39,11 +39,26 @@ impl<T> CacheEntry<T> {
     }
 }
 
+/// In-memory cursor for withdrawal-to-deposit pairing progress.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct WithdrawalPairingCursor {
+    pub(crate) next_deposit_idx: DepositIdx,
+    pub(crate) next_withdrawal_seq: u64,
+}
+
+/// In-memory withdrawal-to-deposit pairings and their FIFO cursor.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct WithdrawalPairing {
+    pairings: BTreeMap<DepositIdx, u64>,
+    cursor: WithdrawalPairingCursor,
+}
+
 /// In-memory cache for bridge monitoring data
 #[derive(Debug, Default, Clone)]
 pub(crate) struct BridgeStatusCache {
     deposits: HashMap<DepositIdx, CacheEntry<DepositInfo>>,
     deposit_info_cursor: DepositIdx,
+    withdrawal_pairing: WithdrawalPairing,
     withdrawals: HashMap<Buf32, CacheEntry<WithdrawalInfo>>,
     reimbursements: HashMap<DepositIdx, CacheEntry<ReimbursementInfo>>,
     operators: Vec<OperatorStatus>,
@@ -56,6 +71,36 @@ impl BridgeStatusCache {
 
     pub(crate) fn set_deposit_info_cursor(&mut self, cursor: DepositIdx) {
         self.deposit_info_cursor = cursor;
+    }
+
+    pub(crate) fn withdrawal_pairing_cursor(&self) -> WithdrawalPairingCursor {
+        self.withdrawal_pairing.cursor
+    }
+
+    #[expect(
+        dead_code,
+        reason = "used when withdrawal status candidates are selected in the next commit"
+    )]
+    pub(crate) fn withdrawal_pairings_from(
+        &self,
+        deposit_idx: DepositIdx,
+    ) -> Vec<(DepositIdx, u64)> {
+        self.withdrawal_pairing
+            .pairings
+            .range(deposit_idx..)
+            .map(|(deposit_idx, withdrawal_seq)| (*deposit_idx, *withdrawal_seq))
+            .collect()
+    }
+
+    pub(crate) fn update_withdrawal_pairings(
+        &mut self,
+        pairings: &[(DepositIdx, u64)],
+        cursor: WithdrawalPairingCursor,
+    ) {
+        self.withdrawal_pairing
+            .pairings
+            .extend(pairings.iter().copied());
+        self.withdrawal_pairing.cursor = cursor;
     }
 
     /// Update deposit cache entry

--- a/backend/crates/bridge/src/cache.rs
+++ b/backend/crates/bridge/src/cache.rs
@@ -1,6 +1,6 @@
-use bitcoin::Txid;
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
+use strata_bridge_primitives::types::DepositIdx;
 use strata_primitives::buf::Buf32;
 
 use super::types::{
@@ -42,20 +42,25 @@ impl<T> CacheEntry<T> {
 /// In-memory cache for bridge monitoring data
 #[derive(Debug, Default, Clone)]
 pub(crate) struct BridgeStatusCache {
-    deposits: HashMap<Txid, CacheEntry<DepositInfo>>,
+    deposits: HashMap<DepositIdx, CacheEntry<DepositInfo>>,
     withdrawals: HashMap<Buf32, CacheEntry<WithdrawalInfo>>,
-    reimbursements: HashMap<Txid, CacheEntry<ReimbursementInfo>>,
+    reimbursements: HashMap<DepositIdx, CacheEntry<ReimbursementInfo>>,
     operators: Vec<OperatorStatus>,
 }
 
 impl BridgeStatusCache {
     /// Update deposit cache entry
-    pub(crate) fn update_deposit(&mut self, txid: Txid, info: DepositInfo, confirmations: u64) {
-        if let Some(entry) = self.deposits.get_mut(&txid) {
+    pub(crate) fn update_deposit(
+        &mut self,
+        deposit_idx: DepositIdx,
+        info: DepositInfo,
+        confirmations: u64,
+    ) {
+        if let Some(entry) = self.deposits.get_mut(&deposit_idx) {
             entry.update(info, confirmations);
         } else {
             self.deposits
-                .insert(txid, CacheEntry::new(info, confirmations));
+                .insert(deposit_idx, CacheEntry::new(info, confirmations));
         }
     }
 
@@ -77,15 +82,15 @@ impl BridgeStatusCache {
     /// Update reimbursement cache entry
     pub(crate) fn update_reimbursement(
         &mut self,
-        txid: Txid,
+        deposit_idx: DepositIdx,
         info: ReimbursementInfo,
         confirmations: u64,
     ) {
-        if let Some(entry) = self.reimbursements.get_mut(&txid) {
+        if let Some(entry) = self.reimbursements.get_mut(&deposit_idx) {
             entry.update(info, confirmations);
         } else {
             self.reimbursements
-                .insert(txid, CacheEntry::new(info, confirmations));
+                .insert(deposit_idx, CacheEntry::new(info, confirmations));
         }
     }
 
@@ -100,9 +105,9 @@ impl BridgeStatusCache {
     }
 
     /// Batch update deposits
-    pub(crate) fn apply_deposit_updates(&mut self, updates: Vec<(Txid, DepositInfo, u64)>) {
-        for (txid, info, confirmations) in updates {
-            self.update_deposit(txid, info, confirmations);
+    pub(crate) fn apply_deposit_updates(&mut self, updates: Vec<(DepositIdx, DepositInfo, u64)>) {
+        for (deposit_idx, info, confirmations) in updates {
+            self.update_deposit(deposit_idx, info, confirmations);
         }
     }
 
@@ -116,22 +121,22 @@ impl BridgeStatusCache {
     /// Batch update reimbursements
     pub(crate) fn apply_reimbursement_updates(
         &mut self,
-        updates: Vec<(Txid, ReimbursementInfo, u64)>,
+        updates: Vec<(DepositIdx, ReimbursementInfo, u64)>,
     ) {
-        for (txid, info, confirmations) in updates {
-            self.update_reimbursement(txid, info, confirmations);
+        for (deposit_idx, info, confirmations) in updates {
+            self.update_reimbursement(deposit_idx, info, confirmations);
         }
     }
 
     /// Filter deposits based on status condition
-    pub(crate) fn filter_deposits<F>(&self, filter: F) -> Vec<(Txid, DepositInfo)>
+    pub(crate) fn filter_deposits<F>(&self, filter: F) -> Vec<(DepositIdx, DepositInfo)>
     where
         F: Fn(&DepositStatus) -> bool,
     {
         self.deposits
             .iter()
             .filter(|(_, entry)| filter(&entry.data.status))
-            .map(|(txid, entry)| (*txid, entry.data))
+            .map(|(deposit_idx, entry)| (*deposit_idx, entry.data))
             .collect()
     }
 
@@ -148,25 +153,29 @@ impl BridgeStatusCache {
     }
 
     /// Filter reimbursements based on status condition
-    pub(crate) fn filter_reimbursements<F>(&self, filter: F) -> Vec<(Txid, ReimbursementInfo)>
+    pub(crate) fn filter_reimbursements<F>(&self, filter: F) -> Vec<(DepositIdx, ReimbursementInfo)>
     where
         F: Fn(&ReimbursementStatus) -> bool,
     {
         self.reimbursements
             .iter()
             .filter(|(_, entry)| filter(&entry.data.status))
-            .map(|(txid, entry)| (*txid, entry.data))
+            .map(|(deposit_idx, entry)| (*deposit_idx, entry.data))
             .collect()
     }
 
     /// Purge specific deposit entries
-    pub(crate) fn purge_deposits(&mut self, deposits_to_purge: Vec<Txid>) {
-        for txid in deposits_to_purge {
-            self.deposits.remove(&txid);
+    pub(crate) fn purge_deposits(&mut self, deposits_to_purge: Vec<DepositIdx>) {
+        for deposit_idx in deposits_to_purge {
+            self.deposits.remove(&deposit_idx);
         }
     }
 
     /// Purge specific withdrawal entries
+    #[expect(
+        dead_code,
+        reason = "withdrawal purge resumes when deposit-index pairing is wired in the next commit"
+    )]
     pub(crate) fn purge_withdrawals(&mut self, withdrawals_to_purge: Vec<Buf32>) {
         for request_id in withdrawals_to_purge {
             self.withdrawals.remove(&request_id);
@@ -174,9 +183,9 @@ impl BridgeStatusCache {
     }
 
     /// Purge specific reimbursement entries
-    pub(crate) fn purge_reimbursements(&mut self, reimbursements_to_purge: Vec<Txid>) {
-        for txid in reimbursements_to_purge {
-            self.reimbursements.remove(&txid);
+    pub(crate) fn purge_reimbursements(&mut self, reimbursements_to_purge: Vec<DepositIdx>) {
+        for deposit_idx in reimbursements_to_purge {
+            self.reimbursements.remove(&deposit_idx);
         }
     }
 }

--- a/backend/crates/bridge/src/cache.rs
+++ b/backend/crates/bridge/src/cache.rs
@@ -43,12 +43,21 @@ impl<T> CacheEntry<T> {
 #[derive(Debug, Default, Clone)]
 pub(crate) struct BridgeStatusCache {
     deposits: HashMap<DepositIdx, CacheEntry<DepositInfo>>,
+    deposit_info_cursor: DepositIdx,
     withdrawals: HashMap<Buf32, CacheEntry<WithdrawalInfo>>,
     reimbursements: HashMap<DepositIdx, CacheEntry<ReimbursementInfo>>,
     operators: Vec<OperatorStatus>,
 }
 
 impl BridgeStatusCache {
+    pub(crate) fn deposit_info_cursor(&self) -> DepositIdx {
+        self.deposit_info_cursor
+    }
+
+    pub(crate) fn set_deposit_info_cursor(&mut self, cursor: DepositIdx) {
+        self.deposit_info_cursor = cursor;
+    }
+
     /// Update deposit cache entry
     pub(crate) fn update_deposit(
         &mut self,

--- a/backend/crates/bridge/src/context.rs
+++ b/backend/crates/bridge/src/context.rs
@@ -79,7 +79,10 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
-    use crate::types::{DepositInfo, DepositStatus};
+    use crate::{
+        state::DepositInfoUpdate,
+        types::{DepositInfo, DepositStatus},
+    };
 
     #[tokio::test]
     async fn bridge_status_reflects_cached_state() {
@@ -102,15 +105,18 @@ mod tests {
 
         context
             .state()
-            .apply_deposit_updates(vec![(
-                0,
-                DepositInfo {
-                    deposit_request_txid,
-                    deposit_txid: Some(deposit_txid),
-                    status: DepositStatus::Complete,
-                },
-                1,
-            )])
+            .apply_deposit_info_updates(
+                vec![DepositInfoUpdate {
+                    deposit_idx: 0,
+                    info: DepositInfo {
+                        deposit_request_txid,
+                        deposit_txid: Some(deposit_txid),
+                        status: DepositStatus::Complete,
+                    },
+                    confirmations: Some(1),
+                }],
+                6,
+            )
             .await;
 
         let status = context.bridge_status().await;

--- a/backend/crates/bridge/src/context.rs
+++ b/backend/crates/bridge/src/context.rs
@@ -4,7 +4,7 @@ use std::sync::{
 };
 
 use tokio::sync::Notify;
-use tracing::debug;
+use tokio::time::Duration;
 
 use super::{
     bridge_rpc::RpcClientManager, db::WithdrawalIndexerDbSled, esplora::EsploraClient,
@@ -73,11 +73,24 @@ impl BridgeMonitoringContext {
         }
     }
 
-    pub(crate) async fn wait_until_status_available(&self) {
-        if !self.status_available.load(Ordering::Acquire) {
-            debug!("Waiting for initial bridge status query to complete");
-            self.initial_status_query_complete.notified().await;
+    pub(crate) fn initial_status_wait_timeout(&self) -> Duration {
+        Duration::from_secs(self.config.initial_status_wait_timeout_s().max(1))
+    }
+
+    pub(crate) async fn wait_until_initial_status(&self) {
+        if self.status_available.load(Ordering::Acquire) {
+            return;
         }
+
+        let notified = self.initial_status_query_complete.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+
+        if self.status_available.load(Ordering::Acquire) {
+            return;
+        }
+
+        notified.await;
     }
 
     pub(crate) async fn bridge_status(&self) -> BridgeStatus {
@@ -96,9 +109,8 @@ mod tests {
         types::{DepositInfo, DepositStatus},
     };
 
-    #[tokio::test]
-    async fn bridge_status_reflects_cached_state() {
-        let config: BridgeMonitoringConfig = toml::from_str(
+    fn test_config() -> BridgeMonitoringConfig {
+        toml::from_str(
             r#"
             esplora_url = "http://localhost:3000"
             max_tx_confirmations = 6
@@ -106,10 +118,18 @@ mod tests {
             operators = []
             "#,
         )
-        .expect("test config should deserialize");
+        .expect("test config should deserialize")
+    }
+
+    fn test_context() -> BridgeMonitoringContext {
         let withdrawal_index =
             Arc::new(WithdrawalIndexerDbSled::open_temporary().expect("open db"));
-        let context = BridgeMonitoringContext::new(config, withdrawal_index);
+        BridgeMonitoringContext::new(test_config(), withdrawal_index)
+    }
+
+    #[tokio::test]
+    async fn bridge_status_reflects_cached_state() {
+        let context = test_context();
         let deposit_request_txid =
             Txid::from_str("0101010101010101010101010101010101010101010101010101010101010101")
                 .expect("valid txid");
@@ -141,5 +161,31 @@ mod tests {
             deposit_request_txid
         );
         assert_eq!(status.deposits[0].deposit_txid, Some(deposit_txid));
+    }
+
+    #[tokio::test]
+    async fn wait_for_initial_status_times_out_when_unavailable() {
+        let context = test_context();
+
+        assert!(tokio::time::timeout(
+            Duration::from_millis(1),
+            context.wait_until_initial_status()
+        )
+        .await
+        .is_err());
+    }
+
+    #[tokio::test]
+    async fn wait_for_initial_status_returns_when_available() {
+        let context = test_context();
+
+        context.mark_status_available();
+
+        assert!(tokio::time::timeout(
+            Duration::from_millis(1),
+            context.wait_until_initial_status()
+        )
+        .await
+        .is_ok());
     }
 }

--- a/backend/crates/bridge/src/context.rs
+++ b/backend/crates/bridge/src/context.rs
@@ -3,12 +3,17 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::Notify;
 use tracing::debug;
 
-use super::{state::BridgeMonitoringState, types::BridgeStatus};
+use super::{
+    bridge_rpc::RpcClientManager, esplora::EsploraClient, state::BridgeMonitoringState,
+    types::BridgeStatus,
+};
 use status_config::BridgeMonitoringConfig;
 
 /// Bridge monitoring task context.
 pub struct BridgeMonitoringContext {
     config: BridgeMonitoringConfig,
+    bridge_rpc: RpcClientManager,
+    esplora_client: EsploraClient,
     state: BridgeMonitoringState,
     status_available: AtomicBool,
     initial_status_query_complete: Notify,
@@ -16,8 +21,14 @@ pub struct BridgeMonitoringContext {
 
 impl BridgeMonitoringContext {
     pub fn new(config: BridgeMonitoringConfig) -> Self {
+        let bridge_rpc = RpcClientManager::new(&config);
+        let esplora_client =
+            EsploraClient::new(config.esplora_url(), config.esplora_request_timeout_s());
+
         Self {
             config,
+            bridge_rpc,
+            esplora_client,
             state: BridgeMonitoringState::default(),
             status_available: AtomicBool::new(false),
             initial_status_query_complete: Notify::new(),
@@ -26,6 +37,14 @@ impl BridgeMonitoringContext {
 
     pub(crate) fn config(&self) -> &BridgeMonitoringConfig {
         &self.config
+    }
+
+    pub(crate) fn bridge_rpc(&self) -> &RpcClientManager {
+        &self.bridge_rpc
+    }
+
+    pub(crate) fn esplora(&self) -> &EsploraClient {
+        &self.esplora_client
     }
 
     pub(crate) fn state(&self) -> &BridgeMonitoringState {

--- a/backend/crates/bridge/src/context.rs
+++ b/backend/crates/bridge/src/context.rs
@@ -28,6 +28,10 @@ impl BridgeMonitoringContext {
         &self.config
     }
 
+    #[expect(
+        dead_code,
+        reason = "read-only state access is used by later status lifecycle commits"
+    )]
     pub(crate) async fn with_state<T>(&self, f: impl FnOnce(&BridgeStatusCache) -> T) -> T {
         let state = self.state.read().await;
         f(&state)
@@ -109,7 +113,7 @@ mod tests {
         context
             .with_state_mut(|state| {
                 state.update_deposit(
-                    deposit_request_txid,
+                    0,
                     DepositInfo {
                         deposit_request_txid,
                         deposit_txid: Some(deposit_txid),

--- a/backend/crates/bridge/src/context.rs
+++ b/backend/crates/bridge/src/context.rs
@@ -1,15 +1,15 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use tokio::sync::{Notify, RwLock};
+use tokio::sync::Notify;
 use tracing::debug;
 
-use super::{cache::BridgeStatusCache, types::BridgeStatus};
+use super::{state::BridgeMonitoringState, types::BridgeStatus};
 use status_config::BridgeMonitoringConfig;
 
 /// Bridge monitoring task context.
 pub struct BridgeMonitoringContext {
     config: BridgeMonitoringConfig,
-    state: RwLock<BridgeStatusCache>,
+    state: BridgeMonitoringState,
     status_available: AtomicBool,
     initial_status_query_complete: Notify,
 }
@@ -18,7 +18,7 @@ impl BridgeMonitoringContext {
     pub fn new(config: BridgeMonitoringConfig) -> Self {
         Self {
             config,
-            state: RwLock::new(BridgeStatusCache::default()),
+            state: BridgeMonitoringState::default(),
             status_available: AtomicBool::new(false),
             initial_status_query_complete: Notify::new(),
         }
@@ -28,18 +28,8 @@ impl BridgeMonitoringContext {
         &self.config
     }
 
-    #[expect(
-        dead_code,
-        reason = "read-only state access is used by later status lifecycle commits"
-    )]
-    pub(crate) async fn with_state<T>(&self, f: impl FnOnce(&BridgeStatusCache) -> T) -> T {
-        let state = self.state.read().await;
-        f(&state)
-    }
-
-    pub(crate) async fn with_state_mut<T>(&self, f: impl FnOnce(&mut BridgeStatusCache) -> T) -> T {
-        let mut state = self.state.write().await;
-        f(&mut state)
+    pub(crate) fn state(&self) -> &BridgeMonitoringState {
+        &self.state
     }
 
     pub(crate) fn mark_status_available(&self) {
@@ -60,26 +50,7 @@ impl BridgeMonitoringContext {
     }
 
     pub(crate) async fn bridge_status(&self) -> BridgeStatus {
-        let cache = self.state.read().await;
-
-        BridgeStatus {
-            operators: cache.get_operators(),
-            deposits: cache
-                .filter_deposits(|_| true)
-                .into_iter()
-                .map(|(_, info)| info)
-                .collect(),
-            withdrawals: cache
-                .filter_withdrawals(|_| true)
-                .into_iter()
-                .map(|(_, info)| info)
-                .collect(),
-            reimbursements: cache
-                .filter_reimbursements(|_| true)
-                .into_iter()
-                .map(|(_, info)| info)
-                .collect(),
-        }
+        self.state.bridge_status().await
     }
 }
 
@@ -111,17 +82,16 @@ mod tests {
                 .expect("valid txid");
 
         context
-            .with_state_mut(|state| {
-                state.update_deposit(
-                    0,
-                    DepositInfo {
-                        deposit_request_txid,
-                        deposit_txid: Some(deposit_txid),
-                        status: DepositStatus::Complete,
-                    },
-                    1,
-                );
-            })
+            .state()
+            .apply_deposit_updates(vec![(
+                0,
+                DepositInfo {
+                    deposit_request_txid,
+                    deposit_txid: Some(deposit_txid),
+                    status: DepositStatus::Complete,
+                },
+                1,
+            )])
             .await;
 
         let status = context.bridge_status().await;

--- a/backend/crates/bridge/src/context.rs
+++ b/backend/crates/bridge/src/context.rs
@@ -1,11 +1,14 @@
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 use tokio::sync::Notify;
 use tracing::debug;
 
 use super::{
-    bridge_rpc::RpcClientManager, esplora::EsploraClient, state::BridgeMonitoringState,
-    types::BridgeStatus,
+    bridge_rpc::RpcClientManager, db::WithdrawalIndexerDbSled, esplora::EsploraClient,
+    state::BridgeMonitoringState, types::BridgeStatus,
 };
 use status_config::BridgeMonitoringConfig;
 
@@ -14,13 +17,17 @@ pub struct BridgeMonitoringContext {
     config: BridgeMonitoringConfig,
     bridge_rpc: RpcClientManager,
     esplora_client: EsploraClient,
+    withdrawal_index: Arc<WithdrawalIndexerDbSled>,
     state: BridgeMonitoringState,
     status_available: AtomicBool,
     initial_status_query_complete: Notify,
 }
 
 impl BridgeMonitoringContext {
-    pub fn new(config: BridgeMonitoringConfig) -> Self {
+    pub fn new(
+        config: BridgeMonitoringConfig,
+        withdrawal_index: Arc<WithdrawalIndexerDbSled>,
+    ) -> Self {
         let bridge_rpc = RpcClientManager::new(&config);
         let esplora_client =
             EsploraClient::new(config.esplora_url(), config.esplora_request_timeout_s());
@@ -29,6 +36,7 @@ impl BridgeMonitoringContext {
             config,
             bridge_rpc,
             esplora_client,
+            withdrawal_index,
             state: BridgeMonitoringState::default(),
             status_available: AtomicBool::new(false),
             initial_status_query_complete: Notify::new(),
@@ -45,6 +53,10 @@ impl BridgeMonitoringContext {
 
     pub(crate) fn esplora(&self) -> &EsploraClient {
         &self.esplora_client
+    }
+
+    pub(crate) fn withdrawal_index(&self) -> &WithdrawalIndexerDbSled {
+        self.withdrawal_index.as_ref()
     }
 
     pub(crate) fn state(&self) -> &BridgeMonitoringState {
@@ -95,7 +107,9 @@ mod tests {
             "#,
         )
         .expect("test config should deserialize");
-        let context = BridgeMonitoringContext::new(config);
+        let withdrawal_index =
+            Arc::new(WithdrawalIndexerDbSled::open_temporary().expect("open db"));
+        let context = BridgeMonitoringContext::new(config, withdrawal_index);
         let deposit_request_txid =
             Txid::from_str("0101010101010101010101010101010101010101010101010101010101010101")
                 .expect("valid txid");

--- a/backend/crates/bridge/src/db/error.rs
+++ b/backend/crates/bridge/src/db/error.rs
@@ -1,9 +1,7 @@
-use std::path::PathBuf;
-
 use crate::db::types::DbWithdrawalEventKey;
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
-pub enum WithdrawalIndexConsistencyError {
+pub(crate) enum WithdrawalIndexConsistencyError {
     #[error("withdrawal sequence overflow at {0}")]
     SeqOverflow(u64),
 
@@ -15,10 +13,7 @@ pub enum WithdrawalIndexConsistencyError {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum DbError {
-    #[error("create data dir {0:?}: {1}")]
-    CreateDataDir(PathBuf, #[source] std::io::Error),
-
+pub(crate) enum DbError {
     #[error("withdrawal event contains no requests")]
     EmptyWithdrawalEvent,
 
@@ -44,4 +39,4 @@ impl From<sled::Error> for DbError {
     }
 }
 
-pub type DbResult<T> = Result<T, DbError>;
+pub(crate) type DbResult<T> = Result<T, DbError>;

--- a/backend/crates/bridge/src/db/error.rs
+++ b/backend/crates/bridge/src/db/error.rs
@@ -2,18 +2,8 @@ use std::path::PathBuf;
 
 use crate::db::types::DbWithdrawalEventKey;
 
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "withdrawal-index consistency errors are constructed by follow-up indexer/pairing commits"
-    )
-)]
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum WithdrawalIndexConsistencyError {
-    #[error("withdrawal sequence {0} does not exist")]
-    MissingSeq(u64),
-
     #[error("withdrawal sequence overflow at {0}")]
     SeqOverflow(u64),
 
@@ -22,12 +12,6 @@ pub enum WithdrawalIndexConsistencyError {
 
     #[error("withdrawal event index inconsistent for {0:?}: first_seq {1}, count {2}")]
     EventIndexInconsistent(DbWithdrawalEventKey, u64, u32),
-
-    #[error("withdrawal seq {0} already paired to deposit_idx {1}, requested {2}")]
-    SeqPairingConflict(u64, u32, u32),
-
-    #[error("deposit_idx {0} already paired to withdrawal seq {1}, requested {2}")]
-    DepositPairingConflict(u32, u64, u64),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/backend/crates/bridge/src/db/mod.rs
+++ b/backend/crates/bridge/src/db/mod.rs
@@ -4,3 +4,5 @@ pub(crate) mod error;
 pub(crate) mod traits;
 pub(crate) mod types;
 pub(crate) mod withdrawal_index;
+
+pub use withdrawal_index::db::WithdrawalIndexerDbSled;

--- a/backend/crates/bridge/src/db/traits.rs
+++ b/backend/crates/bridge/src/db/traits.rs
@@ -27,13 +27,6 @@ pub(crate) trait WithdrawalIndexerDb: Send + Sync {
     /// Fetches indexed withdrawal requests in ascending FIFO order.
     ///
     /// The result starts at `start_seq` and contains at most `limit` rows.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "used when bridge status consumes indexed withdrawals"
-        )
-    )]
     fn fetch_withdrawal_requests_from(
         &self,
         start_seq: u64,

--- a/backend/crates/bridge/src/db/traits.rs
+++ b/backend/crates/bridge/src/db/traits.rs
@@ -1,40 +1,45 @@
 use crate::db::{
     error::DbResult,
-    types::{DbIndexerState, DbWithdrawalEventIndex, DbWithdrawalEventKey, DbWithdrawalRequest},
+    types::{DbIndexerState, DbWithdrawalEventIndex, DbWithdrawalRequest, DbWithdrawalRequestRow},
 };
 
-/// Storage contract for the EVM withdrawal-intent indexer.
+/// Storage contract for indexed EVM withdrawal-intent events.
 ///
-/// Two concerns share this trait:
-/// - the FIFO sequence of expanded `WithdrawalIntentEvent` requests (with
-///   idempotent insertion via the event-key reverse index and a
-///   `last_scanned_block` checkpoint), and
-/// - the seq ↔ deposit_idx pairing populated once a withdrawal is matched
-///   to a bridge deposit.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "pairing methods are consumed by the pairing task in a follow-up commit"
-    )
-)]
+/// This trait owns the FIFO sequence of expanded `WithdrawalIntentEvent`
+/// requests, idempotent insertion via the event-key reverse index, and the
+/// indexer's [`DbIndexerState`].
 pub(crate) trait WithdrawalIndexerDb: Send + Sync {
+    /// Returns the stored state for an indexer task.
     fn get_indexer_state(&self, task: &str) -> DbResult<Option<DbIndexerState>>;
+
+    /// Stores the state for an indexer task.
     fn put_indexer_state(&self, task: &str, state: &DbIndexerState) -> DbResult<()>;
 
+    /// Inserts one EVM withdrawal-intent event expanded into FIFO requests.
+    ///
+    /// Replaying the same event is idempotent and returns the existing
+    /// persisted sequence range.
     fn insert_withdrawal_event(
         &self,
         requests: &[DbWithdrawalRequest],
     ) -> DbResult<DbWithdrawalEventIndex>;
-    fn get_withdrawal_request(&self, seq: u64) -> DbResult<Option<DbWithdrawalRequest>>;
-    fn get_withdrawal_event_index(
-        &self,
-        key: &DbWithdrawalEventKey,
-    ) -> DbResult<Option<DbWithdrawalEventIndex>>;
-    fn max_withdrawal_seq(&self) -> DbResult<Option<u64>>;
 
-    fn insert_pairing(&self, seq: u64, deposit_idx: u32) -> DbResult<()>;
-    fn get_deposit_idx(&self, seq: u64) -> DbResult<Option<u32>>;
-    fn get_seq_by_deposit_idx(&self, deposit_idx: u32) -> DbResult<Option<u64>>;
-    fn list_unpaired_seqs(&self) -> DbResult<Vec<u64>>;
+    /// Fetches indexed withdrawal requests in ascending FIFO order.
+    ///
+    /// The result starts at `start_seq` and contains at most `limit` rows.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "used when bridge status consumes indexed withdrawals"
+        )
+    )]
+    fn fetch_withdrawal_requests_from(
+        &self,
+        start_seq: u64,
+        limit: usize,
+    ) -> DbResult<Vec<DbWithdrawalRequestRow>>;
+
+    /// Returns the largest indexed withdrawal sequence number.
+    fn max_withdrawal_seq(&self) -> DbResult<Option<u64>>;
 }

--- a/backend/crates/bridge/src/db/types.rs
+++ b/backend/crates/bridge/src/db/types.rs
@@ -61,3 +61,10 @@ pub(crate) struct DbWithdrawalRequest {
     /// EVM block number that contained the event.
     pub(crate) block_number: u64,
 }
+
+/// Indexed withdrawal request row returned from the withdrawal-index DB.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DbWithdrawalRequestRow {
+    pub(crate) seq: u64,
+    pub(crate) request: DbWithdrawalRequest,
+}

--- a/backend/crates/bridge/src/db/withdrawal_index/db.rs
+++ b/backend/crates/bridge/src/db/withdrawal_index/db.rs
@@ -6,13 +6,13 @@ use typed_sled::{error::Error as TSledError, transaction::SledTransactional, Sle
 use crate::db::{
     error::{DbError, DbResult, WithdrawalIndexConsistencyError},
     traits::WithdrawalIndexerDb,
-    types::{DbIndexerState, DbWithdrawalEventIndex, DbWithdrawalEventKey, DbWithdrawalRequest},
+    types::{
+        DbIndexerState, DbWithdrawalEventIndex, DbWithdrawalEventKey, DbWithdrawalRequest,
+        DbWithdrawalRequestRow,
+    },
 };
 
-use super::schema::{
-    IndexerStateSchema, WithdrawalAssignmentSchema, WithdrawalEventIndexSchema,
-    WithdrawalRequestSchema, WithdrawalSeqByDepositIdxSchema,
-};
+use super::schema::{IndexerStateSchema, WithdrawalEventIndexSchema, WithdrawalRequestSchema};
 
 /// Aborts a sled transaction with an application-level consistency error.
 ///
@@ -40,30 +40,13 @@ fn map_tx_result<T>(result: sled::transaction::TransactionResult<T, TSledError>)
 }
 
 /// Sled-backed withdrawal-indexer database. Owns one [`SledDb`] handle and one
-/// typed tree per concern (indexer state, FIFO request sequence, event index,
-/// pairing).
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "wired in by the indexer task in a follow-up commit"
-    )
-)]
+/// typed tree per concern (indexer state, FIFO request sequence, event index).
 #[derive(Debug)]
 pub(crate) struct WithdrawalIndexerDbSled {
     _db: SledDb,
     state: SledTree<IndexerStateSchema>,
     requests: SledTree<WithdrawalRequestSchema>,
     event_index: SledTree<WithdrawalEventIndexSchema>,
-    assignments: SledTree<WithdrawalAssignmentSchema>,
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "consumed by the pairing task in a follow-up commit"
-        )
-    )]
-    seq_by_deposit_idx: SledTree<WithdrawalSeqByDepositIdxSchema>,
 }
 
 impl WithdrawalIndexerDbSled {
@@ -92,8 +75,6 @@ impl WithdrawalIndexerDbSled {
             state: db.get_tree::<IndexerStateSchema>()?,
             requests: db.get_tree::<WithdrawalRequestSchema>()?,
             event_index: db.get_tree::<WithdrawalEventIndexSchema>()?,
-            assignments: db.get_tree::<WithdrawalAssignmentSchema>()?,
-            seq_by_deposit_idx: db.get_tree::<WithdrawalSeqByDepositIdxSchema>()?,
             _db: db,
         })
     }
@@ -185,76 +166,25 @@ impl WithdrawalIndexerDb for WithdrawalIndexerDbSled {
         ))
     }
 
-    fn get_withdrawal_request(&self, seq: u64) -> DbResult<Option<DbWithdrawalRequest>> {
-        Ok(self.requests.get(&seq)?)
-    }
-
-    fn get_withdrawal_event_index(
+    fn fetch_withdrawal_requests_from(
         &self,
-        key: &DbWithdrawalEventKey,
-    ) -> DbResult<Option<DbWithdrawalEventIndex>> {
-        Ok(self.event_index.get(key)?)
+        start_seq: u64,
+        limit: usize,
+    ) -> DbResult<Vec<DbWithdrawalRequestRow>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut rows = Vec::new();
+        for entry in self.requests.range(start_seq..)?.take(limit) {
+            let (seq, request) = entry?;
+            rows.push(DbWithdrawalRequestRow { seq, request });
+        }
+        Ok(rows)
     }
 
     fn max_withdrawal_seq(&self) -> DbResult<Option<u64>> {
         Ok(self.requests.last()?.map(|(seq, _)| seq))
-    }
-
-    fn insert_pairing(&self, seq: u64, deposit_idx: u32) -> DbResult<()> {
-        map_tx_result(
-            (&self.requests, &self.assignments, &self.seq_by_deposit_idx).transaction(
-                |(requests_tree, assignments_tree, seq_by_deposit_idx_tree)| {
-                    if requests_tree.get(&seq)?.is_none() {
-                        return abort_tx(WithdrawalIndexConsistencyError::MissingSeq(seq));
-                    }
-
-                    if let Some(existing_deposit_idx) = assignments_tree.get(&seq)? {
-                        if existing_deposit_idx != deposit_idx {
-                            return abort_tx(WithdrawalIndexConsistencyError::SeqPairingConflict(
-                                seq,
-                                existing_deposit_idx,
-                                deposit_idx,
-                            ));
-                        }
-                    }
-
-                    if let Some(existing_seq) = seq_by_deposit_idx_tree.get(&deposit_idx)? {
-                        if existing_seq != seq {
-                            return abort_tx(
-                                WithdrawalIndexConsistencyError::DepositPairingConflict(
-                                    deposit_idx,
-                                    existing_seq,
-                                    seq,
-                                ),
-                            );
-                        }
-                    }
-
-                    assignments_tree.insert(&seq, &deposit_idx)?;
-                    seq_by_deposit_idx_tree.insert(&deposit_idx, &seq)?;
-                    Ok(())
-                },
-            ),
-        )
-    }
-
-    fn get_deposit_idx(&self, seq: u64) -> DbResult<Option<u32>> {
-        Ok(self.assignments.get(&seq)?)
-    }
-
-    fn get_seq_by_deposit_idx(&self, deposit_idx: u32) -> DbResult<Option<u64>> {
-        Ok(self.seq_by_deposit_idx.get(&deposit_idx)?)
-    }
-
-    fn list_unpaired_seqs(&self) -> DbResult<Vec<u64>> {
-        let mut unpaired = Vec::new();
-        for entry in self.requests.iter() {
-            let (seq, _) = entry?;
-            if self.assignments.get(&seq)?.is_none() {
-                unpaired.push(seq);
-            }
-        }
-        Ok(unpaired)
     }
 }
 
@@ -270,9 +200,8 @@ mod tests {
     use crate::db::withdrawal_index::{
         mock::MockWithdrawalIndexerDb,
         test_utils::{
-            assert_pairing_conflicts_are_rejected, assert_pairing_requires_existing_seq,
-            assert_pairing_roundtrip, assert_withdrawal_event_replay_is_idempotent,
-            assert_withdrawal_event_roundtrip, make_withdrawal_request,
+            assert_withdrawal_event_replay_is_idempotent, assert_withdrawal_event_roundtrip,
+            make_withdrawal_request,
         },
     };
 
@@ -311,39 +240,6 @@ mod tests {
     }
 
     #[test]
-    fn pairing_roundtrip_sled() {
-        let db = WithdrawalIndexerDbSled::open_temporary().expect("open db");
-        assert_pairing_roundtrip(&db);
-    }
-
-    #[test]
-    fn pairing_roundtrip_mock() {
-        assert_pairing_roundtrip(&MockWithdrawalIndexerDb::default());
-    }
-
-    #[test]
-    fn pairing_conflicts_are_rejected_sled() {
-        let db = WithdrawalIndexerDbSled::open_temporary().expect("open db");
-        assert_pairing_conflicts_are_rejected(&db);
-    }
-
-    #[test]
-    fn pairing_conflicts_are_rejected_mock() {
-        assert_pairing_conflicts_are_rejected(&MockWithdrawalIndexerDb::default());
-    }
-
-    #[test]
-    fn pairing_requires_existing_seq_sled() {
-        let db = WithdrawalIndexerDbSled::open_temporary().expect("open db");
-        assert_pairing_requires_existing_seq(&db);
-    }
-
-    #[test]
-    fn pairing_requires_existing_seq_mock() {
-        assert_pairing_requires_existing_seq(&MockWithdrawalIndexerDb::default());
-    }
-
-    #[test]
     fn rows_persist_across_reopen() {
         let path = make_unique_db_path("reopen");
         let req = make_withdrawal_request(1);
@@ -355,7 +251,6 @@ mod tests {
             let db = WithdrawalIndexerDbSled::open(&path).expect("open db");
             db.insert_withdrawal_event(std::slice::from_ref(&req))
                 .expect("insert event");
-            db.insert_pairing(0, 42).expect("insert pairing");
             db.put_indexer_state("withdrawal_index", &state)
                 .expect("put state");
         }
@@ -363,18 +258,13 @@ mod tests {
         {
             let reopened = WithdrawalIndexerDbSled::open(&path).expect("reopen db");
             assert_eq!(
-                reopened.get_withdrawal_request(0).expect("get request"),
-                Some(req)
-            );
-            assert_eq!(
-                reopened.get_deposit_idx(0).expect("get deposit_idx"),
-                Some(42)
-            );
-            assert_eq!(
                 reopened
-                    .get_seq_by_deposit_idx(42)
-                    .expect("get seq by deposit_idx"),
-                Some(0)
+                    .fetch_withdrawal_requests_from(0, 1)
+                    .expect("fetch request"),
+                vec![crate::db::types::DbWithdrawalRequestRow {
+                    seq: 0,
+                    request: req.clone()
+                }]
             );
             assert_eq!(
                 reopened

--- a/backend/crates/bridge/src/db/withdrawal_index/db.rs
+++ b/backend/crates/bridge/src/db/withdrawal_index/db.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use anyhow::Context;
 use sled::transaction::TransactionError;
 use typed_sled::{error::Error as TSledError, transaction::SledTransactional, SledDb, SledTree};
 
@@ -42,7 +43,7 @@ fn map_tx_result<T>(result: sled::transaction::TransactionResult<T, TSledError>)
 /// Sled-backed withdrawal-indexer database. Owns one [`SledDb`] handle and one
 /// typed tree per concern (indexer state, FIFO request sequence, event index).
 #[derive(Debug)]
-pub(crate) struct WithdrawalIndexerDbSled {
+pub struct WithdrawalIndexerDbSled {
     _db: SledDb,
     state: SledTree<IndexerStateSchema>,
     requests: SledTree<WithdrawalRequestSchema>,
@@ -53,19 +54,27 @@ impl WithdrawalIndexerDbSled {
     /// Open the indexer database under `{datadir}/withdrawal_index`. Creates
     /// intermediate directories if they don't exist; sled itself only creates
     /// the leaf, so a fresh datadir without intermediate parents would fail.
-    pub(crate) fn open(datadir: impl AsRef<Path>) -> DbResult<Self> {
+    pub fn open(datadir: impl AsRef<Path>) -> anyhow::Result<Self> {
         let path = datadir.as_ref().join("withdrawal_index");
         std::fs::create_dir_all(&path)
-            .map_err(|source| DbError::CreateDataDir(path.clone(), source))?;
-        let sled_db = sled::open(path)?;
+            .with_context(|| format!("create withdrawal index dir {}", path.display()))?;
+        let sled_db = sled::open(&path)
+            .with_context(|| format!("open withdrawal index sled db at {}", path.display()))?;
+        // typed-sled codec errors are not Send + Sync, so anyhow::Context cannot preserve them.
         Self::from_sled_db(sled_db)
+            .map_err(|e| anyhow::anyhow!("initialize withdrawal index trees: {e}"))
     }
 
     /// Open a temporary in-memory-like sled database deleted on drop.
     #[cfg(test)]
-    pub fn open_temporary() -> DbResult<Self> {
-        let sled_db = sled::Config::new().temporary(true).open()?;
+    pub fn open_temporary() -> anyhow::Result<Self> {
+        let sled_db = sled::Config::new()
+            .temporary(true)
+            .open()
+            .context("open temporary withdrawal index sled db")?;
+        // typed-sled codec errors are not Send + Sync, so anyhow::Context cannot preserve them.
         Self::from_sled_db(sled_db)
+            .map_err(|e| anyhow::anyhow!("initialize temporary withdrawal index trees: {e}"))
     }
 
     fn from_sled_db(sled_db: sled::Db) -> DbResult<Self> {

--- a/backend/crates/bridge/src/db/withdrawal_index/mock.rs
+++ b/backend/crates/bridge/src/db/withdrawal_index/mock.rs
@@ -8,6 +8,7 @@ use crate::db::{
 
 use crate::db::types::{
     DbIndexerState, DbWithdrawalEventIndex, DbWithdrawalEventKey, DbWithdrawalRequest,
+    DbWithdrawalRequestRow,
 };
 
 /// In-memory withdrawal-indexer database for tests.
@@ -16,8 +17,6 @@ pub(crate) struct MockWithdrawalIndexerDb {
     state: RwLock<BTreeMap<String, DbIndexerState>>,
     requests: RwLock<BTreeMap<u64, DbWithdrawalRequest>>,
     event_index: RwLock<BTreeMap<DbWithdrawalEventKey, DbWithdrawalEventIndex>>,
-    assignments: RwLock<BTreeMap<u64, u32>>,
-    seq_by_deposit_idx: RwLock<BTreeMap<u32, u64>>,
 }
 
 impl WithdrawalIndexerDb for MockWithdrawalIndexerDb {
@@ -112,25 +111,26 @@ impl WithdrawalIndexerDb for MockWithdrawalIndexerDb {
         Ok(index)
     }
 
-    fn get_withdrawal_request(&self, seq: u64) -> DbResult<Option<DbWithdrawalRequest>> {
+    fn fetch_withdrawal_requests_from(
+        &self,
+        start_seq: u64,
+        limit: usize,
+    ) -> DbResult<Vec<DbWithdrawalRequestRow>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
         Ok(self
             .requests
             .read()
             .expect("mock requests lock poisoned")
-            .get(&seq)
-            .cloned())
-    }
-
-    fn get_withdrawal_event_index(
-        &self,
-        key: &DbWithdrawalEventKey,
-    ) -> DbResult<Option<DbWithdrawalEventIndex>> {
-        Ok(self
-            .event_index
-            .read()
-            .expect("mock event_index lock poisoned")
-            .get(key)
-            .copied())
+            .range(start_seq..)
+            .take(limit)
+            .map(|(seq, request)| DbWithdrawalRequestRow {
+                seq: *seq,
+                request: request.clone(),
+            })
+            .collect())
     }
 
     fn max_withdrawal_seq(&self) -> DbResult<Option<u64>> {
@@ -141,83 +141,5 @@ impl WithdrawalIndexerDb for MockWithdrawalIndexerDb {
             .keys()
             .next_back()
             .copied())
-    }
-
-    fn insert_pairing(&self, seq: u64, deposit_idx: u32) -> DbResult<()> {
-        if !self
-            .requests
-            .read()
-            .expect("mock requests lock poisoned")
-            .contains_key(&seq)
-        {
-            return Err(WithdrawalIndexConsistencyError::MissingSeq(seq).into());
-        }
-
-        let mut assignments = self
-            .assignments
-            .write()
-            .expect("mock assignments lock poisoned");
-        let mut seq_by_deposit_idx = self
-            .seq_by_deposit_idx
-            .write()
-            .expect("mock seq_by_deposit_idx lock poisoned");
-
-        if let Some(existing_deposit_idx) = assignments.get(&seq).copied() {
-            if existing_deposit_idx != deposit_idx {
-                return Err(WithdrawalIndexConsistencyError::SeqPairingConflict(
-                    seq,
-                    existing_deposit_idx,
-                    deposit_idx,
-                )
-                .into());
-            }
-        }
-        if let Some(existing_seq) = seq_by_deposit_idx.get(&deposit_idx).copied() {
-            if existing_seq != seq {
-                return Err(WithdrawalIndexConsistencyError::DepositPairingConflict(
-                    deposit_idx,
-                    existing_seq,
-                    seq,
-                )
-                .into());
-            }
-        }
-
-        assignments.insert(seq, deposit_idx);
-        seq_by_deposit_idx.insert(deposit_idx, seq);
-        Ok(())
-    }
-
-    fn get_deposit_idx(&self, seq: u64) -> DbResult<Option<u32>> {
-        Ok(self
-            .assignments
-            .read()
-            .expect("mock assignments lock poisoned")
-            .get(&seq)
-            .copied())
-    }
-
-    fn get_seq_by_deposit_idx(&self, deposit_idx: u32) -> DbResult<Option<u64>> {
-        Ok(self
-            .seq_by_deposit_idx
-            .read()
-            .expect("mock seq_by_deposit_idx lock poisoned")
-            .get(&deposit_idx)
-            .copied())
-    }
-
-    fn list_unpaired_seqs(&self) -> DbResult<Vec<u64>> {
-        let assignments = self
-            .assignments
-            .read()
-            .expect("mock assignments lock poisoned");
-        Ok(self
-            .requests
-            .read()
-            .expect("mock requests lock poisoned")
-            .keys()
-            .copied()
-            .filter(|seq| !assignments.contains_key(seq))
-            .collect())
     }
 }

--- a/backend/crates/bridge/src/db/withdrawal_index/mod.rs
+++ b/backend/crates/bridge/src/db/withdrawal_index/mod.rs
@@ -1,5 +1,5 @@
 //! Persistence for the EVM withdrawal-intent indexer: FIFO sequencing of
-//! withdrawal-request events, plus the seq ↔ deposit_idx pairing.
+//! withdrawal-request events and indexer scan state.
 
 pub(crate) mod db;
 pub(crate) mod schema;

--- a/backend/crates/bridge/src/db/withdrawal_index/schema.rs
+++ b/backend/crates/bridge/src/db/withdrawal_index/schema.rs
@@ -40,27 +40,6 @@ impl Schema for WithdrawalEventIndexSchema {
     type Value = DbWithdrawalEventIndex;
 }
 
-/// FIFO seq → assigned deposit_idx (set when the indexer pairs a withdrawal
-/// to a bridge deposit).
-#[derive(Debug)]
-pub(crate) struct WithdrawalAssignmentSchema;
-
-impl Schema for WithdrawalAssignmentSchema {
-    const TREE_NAME: TreeName = TreeName("withdrawal_assignment");
-    type Key = u64;
-    type Value = u32;
-}
-
-/// Reverse pairing: deposit_idx → FIFO seq.
-#[derive(Debug)]
-pub(crate) struct WithdrawalSeqByDepositIdxSchema;
-
-impl Schema for WithdrawalSeqByDepositIdxSchema {
-    const TREE_NAME: TreeName = TreeName("withdrawal_seq_by_deposit_idx");
-    type Key = u32;
-    type Value = u64;
-}
-
 // ---- Key codecs ----
 
 impl KeyCodec<IndexerStateSchema> for String {
@@ -135,5 +114,3 @@ macro_rules! impl_json_value_codec {
 impl_json_value_codec!(IndexerStateSchema, DbIndexerState);
 impl_json_value_codec!(WithdrawalRequestSchema, DbWithdrawalRequest);
 impl_json_value_codec!(WithdrawalEventIndexSchema, DbWithdrawalEventIndex);
-impl_json_value_codec!(WithdrawalAssignmentSchema, u32);
-impl_json_value_codec!(WithdrawalSeqByDepositIdxSchema, u64);

--- a/backend/crates/bridge/src/db/withdrawal_index/test_utils.rs
+++ b/backend/crates/bridge/src/db/withdrawal_index/test_utils.rs
@@ -2,13 +2,10 @@
 
 use strata_primitives::buf::Buf32;
 
-use crate::db::{
-    error::{DbError, WithdrawalIndexConsistencyError},
-    traits::WithdrawalIndexerDb,
-};
+use crate::db::traits::WithdrawalIndexerDb;
 
 use crate::db::types::{
-    DbIndexerState, DbWithdrawalEventIndex, DbWithdrawalEventKey, DbWithdrawalRequest,
+    DbIndexerState, DbWithdrawalEventIndex, DbWithdrawalRequest, DbWithdrawalRequestRow,
 };
 
 pub(crate) fn make_withdrawal_request(seed: u8) -> DbWithdrawalRequest {
@@ -40,26 +37,23 @@ pub(crate) fn assert_withdrawal_event_roundtrip<D: WithdrawalIndexerDb>(db: &D) 
     );
 
     assert_eq!(
-        db.get_withdrawal_request(0).expect("get seq 0"),
-        Some(req_a.clone())
+        db.fetch_withdrawal_requests_from(0, 2)
+            .expect("fetch request rows"),
+        vec![
+            DbWithdrawalRequestRow {
+                seq: 0,
+                request: req_a.clone()
+            },
+            DbWithdrawalRequestRow {
+                seq: 1,
+                request: req_b.clone()
+            }
+        ]
     );
-    assert_eq!(
-        db.get_withdrawal_request(1).expect("get seq 1"),
-        Some(req_b.clone())
-    );
-    assert_eq!(db.get_withdrawal_request(99).expect("missing"), None);
-
-    let key = DbWithdrawalEventKey {
-        tx_hash: req_a.tx_hash,
-        log_index: req_a.log_index,
-    };
-    assert_eq!(
-        db.get_withdrawal_event_index(&key).expect("lookup event"),
-        Some(DbWithdrawalEventIndex {
-            first_seq: 0,
-            count: 2
-        })
-    );
+    assert!(db
+        .fetch_withdrawal_requests_from(99, 1)
+        .expect("fetch missing rows")
+        .is_empty());
 
     assert_eq!(db.max_withdrawal_seq().expect("max"), Some(1));
 
@@ -93,77 +87,17 @@ pub(crate) fn assert_withdrawal_event_replay_is_idempotent<D: WithdrawalIndexerD
     assert_eq!(second_index, first_index);
     assert_eq!(db.max_withdrawal_seq().expect("max"), Some(1));
     assert_eq!(
-        db.get_withdrawal_request(first_index.first_seq)
-            .expect("first request"),
-        Some(req_a)
-    );
-    assert_eq!(
-        db.get_withdrawal_request(first_index.first_seq + 1)
-            .expect("second request"),
-        Some(req_b)
-    );
-}
-
-pub(crate) fn assert_pairing_roundtrip<D: WithdrawalIndexerDb>(db: &D) {
-    let req = make_withdrawal_request(3);
-    db.insert_withdrawal_event(&[req]).expect("insert");
-
-    assert_eq!(
-        db.list_unpaired_seqs().expect("list unpaired"),
-        vec![0],
-        "newly inserted requests start unpaired"
-    );
-
-    db.insert_pairing(0, 7).expect("pair");
-    assert_eq!(db.get_deposit_idx(0).expect("get deposit_idx"), Some(7));
-    assert_eq!(
-        db.get_seq_by_deposit_idx(7).expect("reverse lookup"),
-        Some(0)
-    );
-    assert!(
-        db.list_unpaired_seqs().expect("list unpaired").is_empty(),
-        "paired requests no longer appear in the unpaired set"
-    );
-}
-
-pub(crate) fn assert_pairing_conflicts_are_rejected<D: WithdrawalIndexerDb>(db: &D) {
-    let req_a = make_withdrawal_request(5);
-    let req_b = make_withdrawal_request(6);
-
-    db.insert_withdrawal_event(&[req_a]).expect("insert first");
-    db.insert_withdrawal_event(&[req_b]).expect("insert second");
-    db.insert_pairing(0, 7).expect("pair first");
-
-    assert!(matches!(
-        db.insert_pairing(0, 8),
-        Err(DbError::Consistency(
-            WithdrawalIndexConsistencyError::SeqPairingConflict(0, 7, 8)
-        ))
-    ));
-    assert!(matches!(
-        db.insert_pairing(1, 7),
-        Err(DbError::Consistency(
-            WithdrawalIndexConsistencyError::DepositPairingConflict(7, 0, 1)
-        ))
-    ));
-}
-
-pub(crate) fn assert_pairing_requires_existing_seq<D: WithdrawalIndexerDb>(db: &D) {
-    assert!(matches!(
-        db.insert_pairing(99, 7),
-        Err(DbError::Consistency(
-            WithdrawalIndexConsistencyError::MissingSeq(99)
-        ))
-    ));
-
-    assert_eq!(
-        db.get_deposit_idx(99).expect("forward lookup"),
-        None,
-        "missing seq must not create an orphan forward pairing"
-    );
-    assert_eq!(
-        db.get_seq_by_deposit_idx(7).expect("reverse lookup"),
-        None,
-        "missing seq must not create an orphan reverse pairing"
+        db.fetch_withdrawal_requests_from(first_index.first_seq, 2)
+            .expect("fetch request rows"),
+        vec![
+            DbWithdrawalRequestRow {
+                seq: first_index.first_seq,
+                request: req_a
+            },
+            DbWithdrawalRequestRow {
+                seq: first_index.first_seq + 1,
+                request: req_b
+            }
+        ]
     );
 }

--- a/backend/crates/bridge/src/lib.rs
+++ b/backend/crates/bridge/src/lib.rs
@@ -3,6 +3,7 @@ mod cache;
 mod context;
 mod db;
 mod esplora;
+mod state;
 mod status;
 mod types;
 mod withdrawal_indexer;

--- a/backend/crates/bridge/src/lib.rs
+++ b/backend/crates/bridge/src/lib.rs
@@ -8,6 +8,7 @@ mod status;
 mod types;
 mod withdrawal_indexer;
 mod withdrawal_requests;
+mod withdrawal_status;
 
 pub use context::BridgeMonitoringContext;
 pub use db::WithdrawalIndexerDbSled;

--- a/backend/crates/bridge/src/lib.rs
+++ b/backend/crates/bridge/src/lib.rs
@@ -7,8 +7,10 @@ mod state;
 mod status;
 mod types;
 mod withdrawal_indexer;
+mod withdrawal_requests;
 
 pub use context::BridgeMonitoringContext;
+pub use db::WithdrawalIndexerDbSled;
 pub use status::{bridge_monitoring_task, get_bridge_status};
 pub use types::BridgeStatus;
 pub use withdrawal_indexer::task::run_withdrawal_indexer;

--- a/backend/crates/bridge/src/state.rs
+++ b/backend/crates/bridge/src/state.rs
@@ -5,7 +5,8 @@ use strata_primitives::buf::Buf32;
 use tokio::sync::RwLock;
 
 use super::{
-    cache::BridgeStatusCache,
+    cache::{BridgeStatusCache, WithdrawalPairingCursor},
+    db::types::DbWithdrawalRequestRow,
     types::{
         BridgeStatus, DepositInfo, DepositStatus, OperatorStatus, ReimbursementInfo,
         ReimbursementStatus, WithdrawalInfo,
@@ -78,6 +79,31 @@ impl BridgeMonitoringState {
         cache.apply_deposit_updates(cache_updates);
         cache.purge_deposits(terminal_deposit_indices_to_purge);
         cache.set_deposit_info_cursor(next_cursor);
+    }
+
+    pub(crate) async fn withdrawal_pairing_cursor(&self) -> WithdrawalPairingCursor {
+        let cache = self.cache.read().await;
+        cache.withdrawal_pairing_cursor()
+    }
+
+    pub(crate) async fn apply_withdrawal_pairings(
+        &self,
+        deposit_indices: &[DepositIdx],
+        withdrawal_requests: &[DbWithdrawalRequestRow],
+    ) -> Vec<(DepositIdx, u64)> {
+        let withdrawal_seqs = withdrawal_requests
+            .iter()
+            .map(|row| row.seq)
+            .collect::<Vec<_>>();
+        let mut cache = self.cache.write().await;
+        let (pairings, next_cursor) = plan_withdrawal_pairings(
+            cache.withdrawal_pairing_cursor(),
+            deposit_indices,
+            &withdrawal_seqs,
+        );
+
+        cache.update_withdrawal_pairings(&pairings, next_cursor);
+        pairings
     }
 
     pub(crate) async fn update_operators(&self, operators: Vec<OperatorStatus>) {
@@ -158,6 +184,45 @@ fn next_deposit_info_cursor(
     next_cursor
 }
 
+fn plan_withdrawal_pairings(
+    cursor: WithdrawalPairingCursor,
+    discovered_deposit_indices: &[DepositIdx],
+    indexed_withdrawal_seqs: &[u64],
+) -> (Vec<(DepositIdx, u64)>, WithdrawalPairingCursor) {
+    let discovered_deposit_indices = discovered_deposit_indices
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let indexed_withdrawal_seqs = indexed_withdrawal_seqs
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let mut next_cursor = cursor;
+    let mut pairings = Vec::new();
+
+    while discovered_deposit_indices.contains(&next_cursor.next_deposit_idx)
+        && indexed_withdrawal_seqs.contains(&next_cursor.next_withdrawal_seq)
+    {
+        pairings.push((
+            next_cursor.next_deposit_idx,
+            next_cursor.next_withdrawal_seq,
+        ));
+
+        let Some(next_deposit_idx) = next_cursor.next_deposit_idx.checked_add(1) else {
+            break;
+        };
+        let Some(next_withdrawal_seq) = next_cursor.next_withdrawal_seq.checked_add(1) else {
+            break;
+        };
+        next_cursor = WithdrawalPairingCursor {
+            next_deposit_idx,
+            next_withdrawal_seq,
+        };
+    }
+
+    (pairings, next_cursor)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -167,5 +232,67 @@ mod tests {
         assert_eq!(next_deposit_info_cursor(0, &[0, 1, 3]), 2);
         assert_eq!(next_deposit_info_cursor(2, &[3, 4]), 2);
         assert_eq!(next_deposit_info_cursor(2, &[2, 3, 4]), 5);
+    }
+
+    #[test]
+    fn withdrawal_pairing_planner_stops_at_deposit_gap() {
+        let (pairings, cursor) =
+            plan_withdrawal_pairings(WithdrawalPairingCursor::default(), &[0, 1, 3], &[0, 1, 2]);
+
+        assert_eq!(pairings, vec![(0, 0), (1, 1)]);
+        assert_eq!(
+            cursor,
+            WithdrawalPairingCursor {
+                next_deposit_idx: 2,
+                next_withdrawal_seq: 2
+            }
+        );
+    }
+
+    #[test]
+    fn withdrawal_pairing_planner_stops_without_indexed_wrt() {
+        let (pairings, cursor) =
+            plan_withdrawal_pairings(WithdrawalPairingCursor::default(), &[0], &[]);
+
+        assert!(pairings.is_empty());
+        assert_eq!(cursor, WithdrawalPairingCursor::default());
+    }
+
+    #[test]
+    fn withdrawal_pairing_planner_does_not_repair_old_indices() {
+        let cursor = WithdrawalPairingCursor {
+            next_deposit_idx: 2,
+            next_withdrawal_seq: 2,
+        };
+        let (pairings, next_cursor) = plan_withdrawal_pairings(cursor, &[0, 1], &[0, 1]);
+
+        assert!(pairings.is_empty());
+        assert_eq!(next_cursor, cursor);
+    }
+
+    #[tokio::test]
+    async fn withdrawal_pairings_apply_atomically_with_cursor() {
+        let state = BridgeMonitoringState::default();
+        let requests = vec![
+            DbWithdrawalRequestRow {
+                seq: 0,
+                request: crate::db::withdrawal_index::test_utils::make_withdrawal_request(1),
+            },
+            DbWithdrawalRequestRow {
+                seq: 1,
+                request: crate::db::withdrawal_index::test_utils::make_withdrawal_request(2),
+            },
+        ];
+
+        let pairings = state.apply_withdrawal_pairings(&[0, 1], &requests).await;
+
+        assert_eq!(pairings, vec![(0, 0), (1, 1)]);
+        assert_eq!(
+            state.withdrawal_pairing_cursor().await,
+            WithdrawalPairingCursor {
+                next_deposit_idx: 2,
+                next_withdrawal_seq: 2
+            }
+        );
     }
 }

--- a/backend/crates/bridge/src/state.rs
+++ b/backend/crates/bridge/src/state.rs
@@ -1,0 +1,90 @@
+use strata_bridge_primitives::types::DepositIdx;
+use strata_primitives::buf::Buf32;
+use tokio::sync::RwLock;
+
+use super::{
+    cache::BridgeStatusCache,
+    types::{
+        BridgeStatus, DepositInfo, DepositStatus, OperatorStatus, ReimbursementInfo,
+        ReimbursementStatus, WithdrawalInfo,
+    },
+};
+
+/// Mutable bridge monitoring state shared by the polling task and HTTP handler.
+#[derive(Debug, Default)]
+pub(crate) struct BridgeMonitoringState {
+    cache: RwLock<BridgeStatusCache>,
+}
+
+impl BridgeMonitoringState {
+    pub(crate) async fn update_operators(&self, operators: Vec<OperatorStatus>) {
+        let mut cache = self.cache.write().await;
+        cache.update_operators(operators);
+    }
+
+    pub(crate) async fn apply_deposit_updates(
+        &self,
+        updates: Vec<(DepositIdx, DepositInfo, u64)>,
+    ) -> Vec<(DepositIdx, DepositInfo)> {
+        let mut cache = self.cache.write().await;
+        cache.apply_deposit_updates(updates);
+        cache.filter_deposits(|s| matches!(s, DepositStatus::Complete | DepositStatus::Failed))
+    }
+
+    pub(crate) async fn purge_deposits(&self, deposits_to_purge: Vec<DepositIdx>) {
+        let mut cache = self.cache.write().await;
+        cache.purge_deposits(deposits_to_purge);
+    }
+
+    pub(crate) async fn apply_withdrawal_updates(
+        &self,
+        updates: Vec<(Buf32, WithdrawalInfo, u64)>,
+    ) {
+        let mut cache = self.cache.write().await;
+        cache.apply_withdrawal_updates(updates);
+    }
+
+    pub(crate) async fn apply_reimbursement_updates(
+        &self,
+        updates: Vec<(DepositIdx, ReimbursementInfo, u64)>,
+    ) -> Vec<(DepositIdx, ReimbursementInfo)> {
+        let mut cache = self.cache.write().await;
+        cache.apply_reimbursement_updates(updates);
+        cache.filter_reimbursements(|s| {
+            matches!(
+                s,
+                ReimbursementStatus::Complete
+                    | ReimbursementStatus::Slashed
+                    | ReimbursementStatus::Aborted
+            )
+        })
+    }
+
+    pub(crate) async fn purge_reimbursements(&self, reimbursements_to_purge: Vec<DepositIdx>) {
+        let mut cache = self.cache.write().await;
+        cache.purge_reimbursements(reimbursements_to_purge);
+    }
+
+    pub(crate) async fn bridge_status(&self) -> BridgeStatus {
+        let cache = self.cache.read().await;
+
+        BridgeStatus {
+            operators: cache.get_operators(),
+            deposits: cache
+                .filter_deposits(|_| true)
+                .into_iter()
+                .map(|(_, info)| info)
+                .collect(),
+            withdrawals: cache
+                .filter_withdrawals(|_| true)
+                .into_iter()
+                .map(|(_, info)| info)
+                .collect(),
+            reimbursements: cache
+                .filter_reimbursements(|_| true)
+                .into_iter()
+                .map(|(_, info)| info)
+                .collect(),
+        }
+    }
+}

--- a/backend/crates/bridge/src/state.rs
+++ b/backend/crates/bridge/src/state.rs
@@ -1,15 +1,14 @@
 use std::collections::BTreeSet;
 
 use strata_bridge_primitives::types::DepositIdx;
-use strata_primitives::buf::Buf32;
 use tokio::sync::RwLock;
 
 use super::{
-    cache::{BridgeStatusCache, WithdrawalPairingCursor},
+    cache::{BridgeStatusCache, WithdrawalPairingCursor, WithdrawalStatusCursor},
     db::types::DbWithdrawalRequestRow,
     types::{
         BridgeStatus, DepositInfo, DepositStatus, OperatorStatus, ReimbursementInfo,
-        ReimbursementStatus, WithdrawalInfo,
+        ReimbursementStatus, WithdrawalInfo, WithdrawalStatus,
     },
 };
 
@@ -21,6 +20,21 @@ use super::{
 pub(crate) struct DepositInfoUpdate {
     pub(crate) deposit_idx: DepositIdx,
     pub(crate) info: DepositInfo,
+    pub(crate) confirmations: Option<u64>,
+}
+
+/// Paired withdrawal candidate whose bridge status can be queried.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct WithdrawalStatusCandidate {
+    pub(crate) deposit_idx: DepositIdx,
+    pub(crate) withdrawal_seq: u64,
+}
+
+/// Withdrawal status update collected during one monitoring tick.
+#[derive(Debug)]
+pub(crate) struct WithdrawalInfoUpdate {
+    pub(crate) deposit_idx: DepositIdx,
+    pub(crate) info: WithdrawalInfo,
     pub(crate) confirmations: Option<u64>,
 }
 
@@ -106,6 +120,21 @@ impl BridgeMonitoringState {
         pairings
     }
 
+    pub(crate) async fn select_withdrawal_status_candidates(
+        &self,
+    ) -> Vec<WithdrawalStatusCandidate> {
+        let cache = self.cache.read().await;
+        let cursor = cache.withdrawal_status_cursor().next_deposit_idx;
+        cache
+            .withdrawal_pairings_from(cursor)
+            .into_iter()
+            .map(|(deposit_idx, withdrawal_seq)| WithdrawalStatusCandidate {
+                deposit_idx,
+                withdrawal_seq,
+            })
+            .collect()
+    }
+
     pub(crate) async fn update_operators(&self, operators: Vec<OperatorStatus>) {
         let mut cache = self.cache.write().await;
         cache.update_operators(operators);
@@ -113,10 +142,41 @@ impl BridgeMonitoringState {
 
     pub(crate) async fn apply_withdrawal_updates(
         &self,
-        updates: Vec<(Buf32, WithdrawalInfo, u64)>,
+        updates: Vec<WithdrawalInfoUpdate>,
+        max_confirmations: u64,
     ) {
+        let mut cache_updates = Vec::new();
+        let mut terminal_deposit_indices_to_purge = Vec::new();
+        let mut withdrawal_deposit_indices_to_purge = Vec::new();
+
+        for update in updates {
+            match update.info.status {
+                WithdrawalStatus::InProgress => {
+                    cache_updates.push((update.deposit_idx, update.info, 0));
+                }
+                WithdrawalStatus::Complete => {
+                    let Some(confirmations) = update.confirmations else {
+                        continue;
+                    };
+
+                    if confirmations >= max_confirmations {
+                        terminal_deposit_indices_to_purge.push(update.deposit_idx);
+                        withdrawal_deposit_indices_to_purge.push(update.deposit_idx);
+                    } else {
+                        cache_updates.push((update.deposit_idx, update.info, confirmations));
+                    }
+                }
+            }
+        }
+
         let mut cache = self.cache.write().await;
-        cache.apply_withdrawal_updates(updates);
+        let next_cursor = next_withdrawal_status_cursor(
+            cache.withdrawal_status_cursor(),
+            &terminal_deposit_indices_to_purge,
+        );
+        cache.apply_withdrawal_updates(cache_updates);
+        cache.purge_withdrawals(withdrawal_deposit_indices_to_purge);
+        cache.set_withdrawal_status_cursor(next_cursor);
     }
 
     pub(crate) async fn apply_reimbursement_updates(
@@ -184,6 +244,28 @@ fn next_deposit_info_cursor(
     next_cursor
 }
 
+fn next_withdrawal_status_cursor(
+    current_cursor: WithdrawalStatusCursor,
+    terminal_deposit_indices_to_purge: &[DepositIdx],
+) -> WithdrawalStatusCursor {
+    let terminal_deposit_indices_to_purge = terminal_deposit_indices_to_purge
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let mut next_cursor = current_cursor.next_deposit_idx;
+
+    while terminal_deposit_indices_to_purge.contains(&next_cursor) {
+        let Some(next) = next_cursor.checked_add(1) else {
+            break;
+        };
+        next_cursor = next;
+    }
+
+    WithdrawalStatusCursor {
+        next_deposit_idx: next_cursor,
+    }
+}
+
 fn plan_withdrawal_pairings(
     cursor: WithdrawalPairingCursor,
     discovered_deposit_indices: &[DepositIdx],
@@ -226,12 +308,40 @@ fn plan_withdrawal_pairings(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bitcoin::{hashes::Hash, Txid};
+    use strata_primitives::buf::Buf32;
 
     #[test]
     fn deposit_info_cursor_advances_over_contiguous_purged_deposits() {
         assert_eq!(next_deposit_info_cursor(0, &[0, 1, 3]), 2);
         assert_eq!(next_deposit_info_cursor(2, &[3, 4]), 2);
         assert_eq!(next_deposit_info_cursor(2, &[2, 3, 4]), 5);
+    }
+
+    #[test]
+    fn withdrawal_status_cursor_advances_over_contiguous_purged_deposits() {
+        assert_eq!(
+            next_withdrawal_status_cursor(
+                WithdrawalStatusCursor {
+                    next_deposit_idx: 0
+                },
+                &[2]
+            ),
+            WithdrawalStatusCursor {
+                next_deposit_idx: 0
+            }
+        );
+        assert_eq!(
+            next_withdrawal_status_cursor(
+                WithdrawalStatusCursor {
+                    next_deposit_idx: 0
+                },
+                &[0, 1]
+            ),
+            WithdrawalStatusCursor {
+                next_deposit_idx: 2
+            }
+        );
     }
 
     #[test]
@@ -294,5 +404,98 @@ mod tests {
                 next_withdrawal_seq: 2
             }
         );
+    }
+
+    #[tokio::test]
+    async fn withdrawal_status_candidates_follow_cursor() {
+        let state = BridgeMonitoringState::default();
+        let requests = vec![
+            DbWithdrawalRequestRow {
+                seq: 0,
+                request: crate::db::withdrawal_index::test_utils::make_withdrawal_request(1),
+            },
+            DbWithdrawalRequestRow {
+                seq: 1,
+                request: crate::db::withdrawal_index::test_utils::make_withdrawal_request(2),
+            },
+        ];
+
+        state.apply_withdrawal_pairings(&[0, 1], &requests).await;
+        assert_eq!(
+            state.select_withdrawal_status_candidates().await,
+            vec![
+                WithdrawalStatusCandidate {
+                    deposit_idx: 0,
+                    withdrawal_seq: 0
+                },
+                WithdrawalStatusCandidate {
+                    deposit_idx: 1,
+                    withdrawal_seq: 1
+                }
+            ]
+        );
+
+        state
+            .apply_withdrawal_updates(
+                vec![WithdrawalInfoUpdate {
+                    deposit_idx: 0,
+                    info: WithdrawalInfo {
+                        withdrawal_request_txid: requests[0].request.tx_hash,
+                        fulfillment_txid: Some(Txid::from_byte_array([3; 32])),
+                        status: WithdrawalStatus::Complete,
+                    },
+                    confirmations: Some(6),
+                }],
+                6,
+            )
+            .await;
+
+        assert_eq!(
+            state.select_withdrawal_status_candidates().await,
+            vec![WithdrawalStatusCandidate {
+                deposit_idx: 1,
+                withdrawal_seq: 1
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn withdrawal_cache_allows_shared_request_tx_hash() {
+        let state = BridgeMonitoringState::default();
+        let withdrawal_request_txid = Buf32([9; 32]);
+
+        state
+            .apply_withdrawal_updates(
+                vec![
+                    WithdrawalInfoUpdate {
+                        deposit_idx: 0,
+                        info: WithdrawalInfo {
+                            withdrawal_request_txid,
+                            fulfillment_txid: None,
+                            status: WithdrawalStatus::InProgress,
+                        },
+                        confirmations: None,
+                    },
+                    WithdrawalInfoUpdate {
+                        deposit_idx: 1,
+                        info: WithdrawalInfo {
+                            withdrawal_request_txid,
+                            fulfillment_txid: None,
+                            status: WithdrawalStatus::InProgress,
+                        },
+                        confirmations: None,
+                    },
+                ],
+                6,
+            )
+            .await;
+
+        let status = state.bridge_status().await;
+
+        assert_eq!(status.withdrawals.len(), 2);
+        assert!(status
+            .withdrawals
+            .iter()
+            .all(|info| info.withdrawal_request_txid == withdrawal_request_txid));
     }
 }

--- a/backend/crates/bridge/src/state.rs
+++ b/backend/crates/bridge/src/state.rs
@@ -4,7 +4,10 @@ use strata_bridge_primitives::types::DepositIdx;
 use tokio::sync::RwLock;
 
 use super::{
-    cache::{BridgeStatusCache, WithdrawalPairingCursor, WithdrawalStatusCursor},
+    cache::{
+        BridgeStatusCache, ReimbursementStatusCursor, WithdrawalPairingCursor,
+        WithdrawalStatusCursor,
+    },
     db::types::DbWithdrawalRequestRow,
     types::{
         BridgeStatus, DepositInfo, DepositStatus, OperatorStatus, ReimbursementInfo,
@@ -35,6 +38,14 @@ pub(crate) struct WithdrawalStatusCandidate {
 pub(crate) struct WithdrawalInfoUpdate {
     pub(crate) deposit_idx: DepositIdx,
     pub(crate) info: WithdrawalInfo,
+    pub(crate) confirmations: Option<u64>,
+}
+
+/// Reimbursement status update collected during one monitoring tick.
+#[derive(Debug)]
+pub(crate) struct ReimbursementInfoUpdate {
+    pub(crate) deposit_idx: DepositIdx,
+    pub(crate) info: ReimbursementInfo,
     pub(crate) confirmations: Option<u64>,
 }
 
@@ -179,25 +190,54 @@ impl BridgeMonitoringState {
         cache.set_withdrawal_status_cursor(next_cursor);
     }
 
-    pub(crate) async fn apply_reimbursement_updates(
-        &self,
-        updates: Vec<(DepositIdx, ReimbursementInfo, u64)>,
-    ) -> Vec<(DepositIdx, ReimbursementInfo)> {
-        let mut cache = self.cache.write().await;
-        cache.apply_reimbursement_updates(updates);
-        cache.filter_reimbursements(|s| {
-            matches!(
-                s,
-                ReimbursementStatus::Complete
-                    | ReimbursementStatus::Slashed
-                    | ReimbursementStatus::Aborted
-            )
-        })
+    pub(crate) async fn select_reimbursement_status_candidates(&self) -> Vec<DepositIdx> {
+        let cache = self.cache.read().await;
+        let cursor = cache.reimbursement_status_cursor().next_deposit_idx;
+        cache
+            .withdrawal_pairings_from(cursor)
+            .into_iter()
+            .map(|(deposit_idx, _)| deposit_idx)
+            .collect()
     }
 
-    pub(crate) async fn purge_reimbursements(&self, reimbursements_to_purge: Vec<DepositIdx>) {
+    pub(crate) async fn apply_reimbursement_updates(
+        &self,
+        updates: Vec<ReimbursementInfoUpdate>,
+        max_confirmations: u64,
+    ) {
+        let mut cache_updates = Vec::new();
+        let mut terminal_deposit_indices_to_purge = Vec::new();
+
+        for update in updates {
+            match update.info.status {
+                ReimbursementStatus::NotStarted => continue,
+                ReimbursementStatus::InProgress => {
+                    cache_updates.push((update.deposit_idx, update.info, 0));
+                }
+                ReimbursementStatus::Slashed
+                | ReimbursementStatus::Aborted
+                | ReimbursementStatus::Complete => {
+                    let Some(confirmations) = update.confirmations else {
+                        continue;
+                    };
+
+                    if confirmations >= max_confirmations {
+                        terminal_deposit_indices_to_purge.push(update.deposit_idx);
+                    } else {
+                        cache_updates.push((update.deposit_idx, update.info, confirmations));
+                    }
+                }
+            }
+        }
+
         let mut cache = self.cache.write().await;
-        cache.purge_reimbursements(reimbursements_to_purge);
+        let next_cursor = next_reimbursement_status_cursor(
+            cache.reimbursement_status_cursor(),
+            &terminal_deposit_indices_to_purge,
+        );
+        cache.apply_reimbursement_updates(cache_updates);
+        cache.purge_reimbursements(terminal_deposit_indices_to_purge);
+        cache.set_reimbursement_status_cursor(next_cursor);
     }
 
     pub(crate) async fn bridge_status(&self) -> BridgeStatus {
@@ -262,6 +302,28 @@ fn next_withdrawal_status_cursor(
     }
 
     WithdrawalStatusCursor {
+        next_deposit_idx: next_cursor,
+    }
+}
+
+fn next_reimbursement_status_cursor(
+    current_cursor: ReimbursementStatusCursor,
+    terminal_deposit_indices_to_purge: &[DepositIdx],
+) -> ReimbursementStatusCursor {
+    let terminal_deposit_indices_to_purge = terminal_deposit_indices_to_purge
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let mut next_cursor = current_cursor.next_deposit_idx;
+
+    while terminal_deposit_indices_to_purge.contains(&next_cursor) {
+        let Some(next) = next_cursor.checked_add(1) else {
+            break;
+        };
+        next_cursor = next;
+    }
+
+    ReimbursementStatusCursor {
         next_deposit_idx: next_cursor,
     }
 }
@@ -339,6 +401,32 @@ mod tests {
                 &[0, 1]
             ),
             WithdrawalStatusCursor {
+                next_deposit_idx: 2
+            }
+        );
+    }
+
+    #[test]
+    fn reimbursement_status_cursor_advances_over_contiguous_purged_deposits() {
+        assert_eq!(
+            next_reimbursement_status_cursor(
+                ReimbursementStatusCursor {
+                    next_deposit_idx: 0
+                },
+                &[2]
+            ),
+            ReimbursementStatusCursor {
+                next_deposit_idx: 0
+            }
+        );
+        assert_eq!(
+            next_reimbursement_status_cursor(
+                ReimbursementStatusCursor {
+                    next_deposit_idx: 0
+                },
+                &[0, 1]
+            ),
+            ReimbursementStatusCursor {
                 next_deposit_idx: 2
             }
         );
@@ -497,5 +585,46 @@ mod tests {
             .withdrawals
             .iter()
             .all(|info| info.withdrawal_request_txid == withdrawal_request_txid));
+    }
+
+    #[tokio::test]
+    async fn reimbursement_status_candidates_follow_cursor() {
+        let state = BridgeMonitoringState::default();
+        let requests = vec![DbWithdrawalRequestRow {
+            seq: 0,
+            request: crate::db::withdrawal_index::test_utils::make_withdrawal_request(1),
+        }];
+
+        assert_eq!(
+            state.select_reimbursement_status_candidates().await,
+            Vec::<DepositIdx>::new()
+        );
+
+        state.apply_withdrawal_pairings(&[0], &requests).await;
+        assert_eq!(
+            state.select_reimbursement_status_candidates().await,
+            vec![0]
+        );
+
+        state
+            .apply_reimbursement_updates(
+                vec![ReimbursementInfoUpdate {
+                    deposit_idx: 0,
+                    info: ReimbursementInfo {
+                        claim_txid: Txid::from_byte_array([4; 32]),
+                        challenge_step: crate::types::ChallengeStep::NotApplicable,
+                        payout_txid: Some(Txid::from_byte_array([5; 32])),
+                        status: ReimbursementStatus::Complete,
+                    },
+                    confirmations: Some(6),
+                }],
+                6,
+            )
+            .await;
+
+        assert_eq!(
+            state.select_reimbursement_status_candidates().await,
+            Vec::<DepositIdx>::new()
+        );
     }
 }

--- a/backend/crates/bridge/src/state.rs
+++ b/backend/crates/bridge/src/state.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use strata_bridge_primitives::types::DepositIdx;
 use strata_primitives::buf::Buf32;
 use tokio::sync::RwLock;
@@ -10,6 +12,17 @@ use super::{
     },
 };
 
+/// Deposit status update collected during one monitoring tick.
+///
+/// The update carries the cache key separately because [`DepositInfo`] is the
+/// dashboard row value and does not include its bridge deposit index.
+#[derive(Debug)]
+pub(crate) struct DepositInfoUpdate {
+    pub(crate) deposit_idx: DepositIdx,
+    pub(crate) info: DepositInfo,
+    pub(crate) confirmations: Option<u64>,
+}
+
 /// Mutable bridge monitoring state shared by the polling task and HTTP handler.
 #[derive(Debug, Default)]
 pub(crate) struct BridgeMonitoringState {
@@ -17,23 +30,59 @@ pub(crate) struct BridgeMonitoringState {
 }
 
 impl BridgeMonitoringState {
+    pub(crate) async fn select_deposit_info_candidates(
+        &self,
+        deposit_indices: &[DepositIdx],
+    ) -> Vec<DepositIdx> {
+        let cache = self.cache.read().await;
+        let deposit_info_cursor = cache.deposit_info_cursor();
+        deposit_indices
+            .iter()
+            .copied()
+            .filter(|deposit_idx| *deposit_idx >= deposit_info_cursor)
+            .collect()
+    }
+
+    pub(crate) async fn apply_deposit_info_updates(
+        &self,
+        updates: Vec<DepositInfoUpdate>,
+        max_confirmations: u64,
+    ) {
+        let mut cache_updates = Vec::new();
+        let mut terminal_deposit_indices_to_purge = Vec::new();
+
+        for update in updates {
+            match update.info.status {
+                DepositStatus::InProgress => {
+                    cache_updates.push((update.deposit_idx, update.info, 0));
+                }
+                DepositStatus::Failed | DepositStatus::Complete => {
+                    let Some(confirmations) = update.confirmations else {
+                        continue;
+                    };
+
+                    if confirmations >= max_confirmations {
+                        terminal_deposit_indices_to_purge.push(update.deposit_idx);
+                    } else {
+                        cache_updates.push((update.deposit_idx, update.info, confirmations));
+                    }
+                }
+            }
+        }
+
+        let mut cache = self.cache.write().await;
+        let next_cursor = next_deposit_info_cursor(
+            cache.deposit_info_cursor(),
+            &terminal_deposit_indices_to_purge,
+        );
+        cache.apply_deposit_updates(cache_updates);
+        cache.purge_deposits(terminal_deposit_indices_to_purge);
+        cache.set_deposit_info_cursor(next_cursor);
+    }
+
     pub(crate) async fn update_operators(&self, operators: Vec<OperatorStatus>) {
         let mut cache = self.cache.write().await;
         cache.update_operators(operators);
-    }
-
-    pub(crate) async fn apply_deposit_updates(
-        &self,
-        updates: Vec<(DepositIdx, DepositInfo, u64)>,
-    ) -> Vec<(DepositIdx, DepositInfo)> {
-        let mut cache = self.cache.write().await;
-        cache.apply_deposit_updates(updates);
-        cache.filter_deposits(|s| matches!(s, DepositStatus::Complete | DepositStatus::Failed))
-    }
-
-    pub(crate) async fn purge_deposits(&self, deposits_to_purge: Vec<DepositIdx>) {
-        let mut cache = self.cache.write().await;
-        cache.purge_deposits(deposits_to_purge);
     }
 
     pub(crate) async fn apply_withdrawal_updates(
@@ -86,5 +135,37 @@ impl BridgeMonitoringState {
                 .map(|(_, info)| info)
                 .collect(),
         }
+    }
+}
+
+fn next_deposit_info_cursor(
+    current_cursor: DepositIdx,
+    terminal_deposit_indices_to_purge: &[DepositIdx],
+) -> DepositIdx {
+    let terminal_deposit_indices_to_purge = terminal_deposit_indices_to_purge
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let mut next_cursor = current_cursor;
+
+    while terminal_deposit_indices_to_purge.contains(&next_cursor) {
+        let Some(next) = next_cursor.checked_add(1) else {
+            break;
+        };
+        next_cursor = next;
+    }
+
+    next_cursor
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deposit_info_cursor_advances_over_contiguous_purged_deposits() {
+        assert_eq!(next_deposit_info_cursor(0, &[0, 1, 3]), 2);
+        assert_eq!(next_deposit_info_cursor(2, &[3, 4]), 2);
+        assert_eq!(next_deposit_info_cursor(2, &[2, 3, 4]), 5);
     }
 }

--- a/backend/crates/bridge/src/status.rs
+++ b/backend/crates/bridge/src/status.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use axum::Json;
 use bitcoin::secp256k1::PublicKey;
-use std::sync::Arc;
+use std::{collections::BTreeSet, sync::Arc};
 use strata_bridge_primitives::types::DepositIdx;
 use strata_primitives::buf::Buf32;
 use strata_primitives::L1Height;
@@ -16,6 +16,7 @@ use super::{
         BridgeStatus, DepositInfo, DepositStatus, OperatorStatus, ReimbursementInfo,
         ReimbursementStatus, WithdrawalInfo,
     },
+    withdrawal_requests,
 };
 
 use tokio::time::{interval, Duration};
@@ -117,6 +118,26 @@ pub async fn bridge_monitoring_task(
             )
             .await;
 
+        let pairing_cursor = context.state().withdrawal_pairing_cursor().await;
+        let new_deposit_indices_count =
+            count_deposit_indices_from(&deposit_indices, pairing_cursor.next_deposit_idx);
+        let withdrawal_requests = withdrawal_requests::fetch_withdrawal_requests(
+            context.withdrawal_index(),
+            pairing_cursor.next_withdrawal_seq,
+            new_deposit_indices_count,
+            context.config().withdrawal_pairing_batch_size(),
+        );
+        let new_pairings = context
+            .state()
+            .apply_withdrawal_pairings(&deposit_indices, &withdrawal_requests)
+            .await;
+        if !new_pairings.is_empty() {
+            info!(
+                pairing_count = new_pairings.len(),
+                "paired indexed withdrawals with deposits"
+            );
+        }
+
         let withdrawal_updates = get_withdrawals().await;
         context
             .state()
@@ -156,6 +177,28 @@ pub async fn bridge_monitoring_task(
     }
 
     Ok(())
+}
+
+fn count_deposit_indices_from(
+    deposit_indices: &[DepositIdx],
+    next_deposit_idx: DepositIdx,
+) -> usize {
+    // This mirrors the state pairing planner's contiguous-prefix rule. The
+    // status tick uses this count to size DB reads; state still enforces the
+    // pairing invariant when it applies the fetched rows.
+    let deposit_indices = deposit_indices.iter().copied().collect::<BTreeSet<_>>();
+    let mut next_deposit_idx = next_deposit_idx;
+    let mut count = 0;
+
+    while deposit_indices.contains(&next_deposit_idx) {
+        count += 1;
+        let Some(next) = next_deposit_idx.checked_add(1) else {
+            break;
+        };
+        next_deposit_idx = next;
+    }
+
+    count
 }
 
 /// Fetch detailed information for all deposits.
@@ -308,4 +351,25 @@ pub async fn get_bridge_status(context: Arc<BridgeMonitoringContext>) -> Json<Br
     context.wait_until_status_available().await;
 
     Json(context.bridge_status().await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counts_deposit_indices_from_cursor() {
+        let cases = [
+            (&[0, 1, 3][..], 0, 2),
+            (&[0, 1, 2, 3][..], 0, 4),
+            (&[0, 1, 3][..], 2, 0),
+        ];
+
+        for (deposit_indices, next_deposit_idx, expected) in cases {
+            assert_eq!(
+                count_deposit_indices_from(deposit_indices, next_deposit_idx),
+                expected
+            );
+        }
+    }
 }

--- a/backend/crates/bridge/src/status.rs
+++ b/backend/crates/bridge/src/status.rs
@@ -9,7 +9,7 @@ use strata_primitives::L1Height;
 use strata_tasks::ShutdownGuard;
 
 use super::{
-    bridge_rpc::{self, RpcClientManager},
+    bridge_rpc,
     context::BridgeMonitoringContext,
     esplora,
     types::{
@@ -98,12 +98,6 @@ pub async fn bridge_monitoring_task(
         context.config().status_refetch_interval(),
     ));
 
-    let rpc_manager = RpcClientManager::new(context.config());
-    let esplora_client = esplora::EsploraClient::new(
-        context.config().esplora_url(),
-        context.config().esplora_request_timeout_s(),
-    );
-
     loop {
         tokio::select! {
             _ = shutdown.wait_for_shutdown() => break,
@@ -116,13 +110,15 @@ pub async fn bridge_monitoring_task(
             let operator_id = format!("Alpen Labs #{}", index + 1);
             let pk_bytes = hex::decode(operator.public_key()).expect("decode to succeed");
             let operator_pk = PublicKey::from_slice(&pk_bytes).expect("conversion to succeed");
-            let status = bridge_rpc::get_operator_status(operator.rpc_url()).await;
+            let status =
+                bridge_rpc::get_operator_status(context.bridge_rpc(), operator.public_key()).await;
             operator_statuses.push(OperatorStatus::new(operator_id, operator_pk, status));
         }
 
         context.state().update_operators(operator_statuses).await;
 
-        let chain_tip_height = match esplora::get_bitcoin_chain_tip_height(&esplora_client).await {
+        let chain_tip_height = match esplora::get_bitcoin_chain_tip_height(context.esplora()).await
+        {
             Ok(height) => height,
             Err(e) => {
                 error!(error = %e, "failed to get Bitcoin chain tip");
@@ -131,7 +127,7 @@ pub async fn bridge_monitoring_task(
         };
         info!(%chain_tip_height, "bitcoin chain tip");
 
-        let deposit_indices = match bridge_rpc::get_deposit_indices(&rpc_manager).await {
+        let deposit_indices = match bridge_rpc::get_deposit_indices(context.bridge_rpc()).await {
             Ok(indices) => indices,
             Err(e) => {
                 error!(error = %e, "failed to fetch bridge deposit indices");
@@ -140,9 +136,9 @@ pub async fn bridge_monitoring_task(
         };
 
         let deposit_infos = get_deposits(
-            &rpc_manager,
+            context.bridge_rpc(),
             context.config(),
-            &esplora_client,
+            context.esplora(),
             chain_tip_height,
             &deposit_indices,
         )
@@ -152,7 +148,7 @@ pub async fn bridge_monitoring_task(
         let deposits_to_purge = determine_deposits_to_purge(
             final_deposits,
             context.config(),
-            &esplora_client,
+            context.esplora(),
             chain_tip_height,
         )
         .await;
@@ -169,9 +165,9 @@ pub async fn bridge_monitoring_task(
         // there are no sound reimbursement candidates to query.
         let reimbursement_deposit_indices = Vec::new();
         let reimbursement_infos = get_reimbursements(
-            &rpc_manager,
+            context.bridge_rpc(),
             context.config(),
-            &esplora_client,
+            context.esplora(),
             chain_tip_height,
             &reimbursement_deposit_indices,
         )
@@ -184,7 +180,7 @@ pub async fn bridge_monitoring_task(
         let reimbursements_to_purge = determine_reimbursements_to_purge(
             final_reimbursements,
             context.config(),
-            &esplora_client,
+            context.esplora(),
             chain_tip_height,
         )
         .await;
@@ -201,7 +197,7 @@ pub async fn bridge_monitoring_task(
 
 /// Fetch detailed information for all deposits.
 async fn get_deposits(
-    rpc_manager: &RpcClientManager,
+    rpc_manager: &bridge_rpc::RpcClientManager,
     config: &BridgeMonitoringConfig,
     esplora_client: &esplora::EsploraClient,
     chain_tip_height: L1Height,
@@ -272,7 +268,7 @@ async fn get_withdrawals() -> Vec<(Buf32, WithdrawalInfo, u64)> {
 /// implementation lands. The caller passes deposit indices whose withdrawals
 /// are known complete.
 async fn get_reimbursements(
-    rpc_manager: &RpcClientManager,
+    rpc_manager: &bridge_rpc::RpcClientManager,
     config: &BridgeMonitoringConfig,
     esplora_client: &esplora::EsploraClient,
     chain_tip_height: L1Height,

--- a/backend/crates/bridge/src/status.rs
+++ b/backend/crates/bridge/src/status.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use axum::Json;
-use bitcoin::secp256k1::PublicKey;
+use bitcoin::{secp256k1::PublicKey, Txid};
 use std::{collections::BTreeSet, sync::Arc};
 use strata_bridge_primitives::types::DepositIdx;
 use strata_primitives::L1Height;
@@ -10,7 +10,7 @@ use super::{
     bridge_rpc,
     context::BridgeMonitoringContext,
     esplora::{self, get_bitcoin_chain_tip_height, EsploraClient},
-    state::DepositInfoUpdate,
+    state::{DepositInfoUpdate, ReimbursementInfoUpdate},
     types::{
         BridgeStatus, DepositInfo, DepositStatus, OperatorStatus, ReimbursementInfo,
         ReimbursementStatus,
@@ -21,42 +21,6 @@ use super::{
 
 use tokio::time::{interval, Duration};
 use tracing::{error, info, warn};
-
-use status_config::BridgeMonitoringConfig;
-
-/// Determine which cached reimbursement entries should be purged.
-async fn determine_reimbursements_to_purge(
-    final_reimbursements: Vec<(DepositIdx, ReimbursementInfo)>,
-    config: &BridgeMonitoringConfig,
-    esplora_client: &EsploraClient,
-    chain_tip_height: L1Height,
-) -> Vec<DepositIdx> {
-    let max_confirmations = config.max_tx_confirmations();
-    let mut reimbursements_to_purge = Vec::new();
-
-    for (deposit_idx, reimbursement_info) in final_reimbursements {
-        let check_txid = match reimbursement_info.status {
-            ReimbursementStatus::Slashed | ReimbursementStatus::Aborted => {
-                reimbursement_info.claim_txid
-            }
-            ReimbursementStatus::Complete => reimbursement_info
-                .payout_txid
-                .unwrap_or(reimbursement_info.claim_txid),
-            ReimbursementStatus::InProgress | ReimbursementStatus::NotStarted => continue,
-        };
-
-        let current_confirmations =
-            esplora::get_tx_confirmations(esplora_client, check_txid, chain_tip_height).await;
-
-        if let Some(confirmations) = current_confirmations {
-            if confirmations >= max_confirmations {
-                reimbursements_to_purge.push(deposit_idx);
-            }
-        }
-    }
-
-    reimbursements_to_purge
-}
 
 /// Periodically fetch bridge status and update bridge cache.
 pub async fn bridge_monitoring_task(
@@ -153,32 +117,23 @@ pub async fn bridge_monitoring_task(
             .apply_withdrawal_updates(withdrawal_updates, context.config().max_tx_confirmations())
             .await;
 
-        // Reimbursement rendering is deferred until the next step wires a
-        // reimbursement scan cursor over completed withdrawal deposit indices.
-        let reimbursement_deposit_indices = Vec::new();
-        let reimbursement_infos = get_reimbursements(
-            context.bridge_rpc(),
-            context.config(),
-            context.esplora(),
-            chain_tip_height,
-            &reimbursement_deposit_indices,
-        )
-        .await;
-
-        let final_reimbursements = context
+        let reimbursement_candidates = context
             .state()
-            .apply_reimbursement_updates(reimbursement_infos)
+            .select_reimbursement_status_candidates()
             .await;
-        let reimbursements_to_purge = determine_reimbursements_to_purge(
-            final_reimbursements,
-            context.config(),
+        let reimbursement_updates = get_reimbursement_updates(
+            context.bridge_rpc(),
             context.esplora(),
             chain_tip_height,
+            &reimbursement_candidates,
         )
         .await;
         context
             .state()
-            .purge_reimbursements(reimbursements_to_purge)
+            .apply_reimbursement_updates(
+                reimbursement_updates,
+                context.config().max_tx_confirmations(),
+            )
             .await;
 
         context.mark_status_available();
@@ -273,75 +228,58 @@ async fn get_deposit_info_updates(
     updates
 }
 
-/// Fetch bridge reimbursement status for completed withdrawals.
-///
-/// At strata-bridge `0ecec67b67db89f6b761ffeaa09af8e7ad864bb1`, the server
-/// returns `Ok(None)` for every `deposit_idx`; this loop produces no
-/// reimbursement rows until the upstream `get_reimbursement_status`
-/// implementation lands. The caller passes deposit indices whose withdrawals
-/// are known complete.
-async fn get_reimbursements(
+/// Fetch reimbursement cache updates for paired deposits.
+async fn get_reimbursement_updates(
     rpc_manager: &bridge_rpc::RpcClientManager,
-    config: &BridgeMonitoringConfig,
     esplora_client: &EsploraClient,
     chain_tip_height: L1Height,
-    deposit_indices: &[DepositIdx],
-) -> Vec<(DepositIdx, ReimbursementInfo, u64)> {
-    let mut reimbursement_infos = Vec::new();
+    candidates: &[DepositIdx],
+) -> Vec<ReimbursementInfoUpdate> {
+    let mut updates = Vec::new();
 
-    for deposit_idx in deposit_indices.iter().copied() {
+    for deposit_idx in candidates.iter().copied() {
         let status = match bridge_rpc::get_reimbursement_status(rpc_manager, deposit_idx).await {
-            Ok(status) => status,
+            Ok(Some(status)) => status,
+            Ok(None) => continue,
             Err(e) => {
                 warn!(deposit_idx, error = %e, "failed to fetch reimbursement status");
                 continue;
             }
-        };
-        let Some(status) = status else {
-            continue;
         };
 
         let Some(info) = ReimbursementInfo::from_status(&status) else {
             continue;
         };
 
-        match info.status {
-            ReimbursementStatus::InProgress => reimbursement_infos.push((deposit_idx, info, 0)),
-            ReimbursementStatus::Slashed | ReimbursementStatus::Aborted => {
-                let confirmations = esplora::get_tx_confirmations(
-                    esplora_client,
-                    info.claim_txid,
-                    chain_tip_height,
-                )
-                .await;
-                if let Some(confirmations) = confirmations {
-                    if confirmations < config.max_tx_confirmations() {
-                        reimbursement_infos.push((deposit_idx, info, confirmations));
-                    }
-                }
-            }
-            ReimbursementStatus::Complete => {
-                let Some(payout_txid) = info.payout_txid else {
+        let confirmations = match info.status {
+            ReimbursementStatus::NotStarted => continue,
+            ReimbursementStatus::InProgress => None,
+            ReimbursementStatus::Slashed
+            | ReimbursementStatus::Aborted
+            | ReimbursementStatus::Complete => {
+                let Some(txid) = terminal_reimbursement_txid(&info) else {
                     continue;
                 };
-                let confirmations =
-                    esplora::get_tx_confirmations(esplora_client, payout_txid, chain_tip_height)
-                        .await;
-                if let Some(confirmations) = confirmations {
-                    if confirmations < config.max_tx_confirmations() {
-                        reimbursement_infos.push((deposit_idx, info, confirmations));
-                    }
-                }
+                esplora::get_tx_confirmations(esplora_client, txid, chain_tip_height).await
             }
-            ReimbursementStatus::NotStarted => continue,
-        }
+        };
+
+        updates.push(ReimbursementInfoUpdate {
+            deposit_idx,
+            info,
+            confirmations,
+        });
     }
 
-    if reimbursement_infos.is_empty() {
-        warn!("no reimbursement infos found");
-    }
+    updates
+}
 
-    reimbursement_infos
+fn terminal_reimbursement_txid(info: &ReimbursementInfo) -> Option<Txid> {
+    match info.status {
+        ReimbursementStatus::Slashed | ReimbursementStatus::Aborted => Some(info.claim_txid),
+        ReimbursementStatus::Complete => info.payout_txid,
+        ReimbursementStatus::InProgress | ReimbursementStatus::NotStarted => None,
+    }
 }
 
 /// Return latest bridge status extracted from cache.

--- a/backend/crates/bridge/src/status.rs
+++ b/backend/crates/bridge/src/status.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
 use axum::Json;
-use bitcoin::{secp256k1::PublicKey, Txid};
+use bitcoin::secp256k1::PublicKey;
 use std::sync::Arc;
-use strata_bridge_rpc::types::{RpcDepositStatus, RpcReimbursementStatus, RpcWithdrawalStatus};
-
+use strata_bridge_primitives::types::DepositIdx;
+use strata_bridge_rpc::types::RpcDepositStatus;
 use strata_primitives::buf::Buf32;
 use strata_primitives::L1Height;
 use strata_tasks::ShutdownGuard;
@@ -14,7 +14,7 @@ use super::{
     esplora,
     types::{
         BridgeStatus, DepositInfo, DepositStatus, OperatorStatus, ReimbursementInfo,
-        ReimbursementStatus, WithdrawalInfo, WithdrawalStatus,
+        ReimbursementStatus, WithdrawalInfo,
     },
 };
 
@@ -23,23 +23,23 @@ use tracing::{error, info, warn};
 
 use status_config::BridgeMonitoringConfig;
 
-/// Determine which cached deposit entries should be purged
+/// Determine which cached deposit entries should be purged.
 async fn determine_deposits_to_purge(
-    final_deposits: Vec<(Txid, DepositInfo)>,
+    final_deposits: Vec<(DepositIdx, DepositInfo)>,
     config: &BridgeMonitoringConfig,
     esplora_client: &esplora::EsploraClient,
     chain_tip_height: L1Height,
-) -> Vec<Txid> {
+) -> Vec<DepositIdx> {
     let max_confirmations = config.max_tx_confirmations();
     let mut deposits_to_purge = Vec::new();
 
-    for (txid, deposit_info) in final_deposits {
+    for (deposit_idx, deposit_info) in final_deposits {
         let check_txid = match deposit_info.status {
             DepositStatus::Failed => deposit_info.deposit_request_txid,
             DepositStatus::Complete => deposit_info
                 .deposit_txid
                 .unwrap_or(deposit_info.deposit_request_txid),
-            DepositStatus::InProgress => unreachable!(),
+            DepositStatus::InProgress => continue,
         };
 
         let current_confirmations =
@@ -47,7 +47,7 @@ async fn determine_deposits_to_purge(
 
         if let Some(confirmations) = current_confirmations {
             if confirmations >= max_confirmations {
-                deposits_to_purge.push(txid);
+                deposits_to_purge.push(deposit_idx);
             }
         }
     }
@@ -55,52 +55,25 @@ async fn determine_deposits_to_purge(
     deposits_to_purge
 }
 
-/// Determine which cached withdrawal entries should be purged
-async fn determine_withdrawals_to_purge(
-    final_withdrawals: Vec<(Buf32, WithdrawalInfo)>,
-    config: &BridgeMonitoringConfig,
-    esplora_client: &esplora::EsploraClient,
-    chain_tip_height: L1Height,
-) -> Vec<Buf32> {
-    let max_confirmations = config.max_tx_confirmations();
-    let mut withdrawals_to_purge = Vec::new();
-
-    for (request_id, withdrawal_info) in final_withdrawals {
-        if let Some(fulfillment_txid) = withdrawal_info.fulfillment_txid {
-            let current_confirmations =
-                esplora::get_tx_confirmations(esplora_client, fulfillment_txid, chain_tip_height)
-                    .await;
-
-            if let Some(confirmations) = current_confirmations {
-                if confirmations >= max_confirmations {
-                    withdrawals_to_purge.push(request_id);
-                }
-            }
-        }
-    }
-
-    withdrawals_to_purge
-}
-
-/// Determine which cached reimbursement entries should be purged
+/// Determine which cached reimbursement entries should be purged.
 async fn determine_reimbursements_to_purge(
-    final_reimbursements: Vec<(Txid, ReimbursementInfo)>,
+    final_reimbursements: Vec<(DepositIdx, ReimbursementInfo)>,
     config: &BridgeMonitoringConfig,
     esplora_client: &esplora::EsploraClient,
     chain_tip_height: L1Height,
-) -> Vec<Txid> {
+) -> Vec<DepositIdx> {
     let max_confirmations = config.max_tx_confirmations();
     let mut reimbursements_to_purge = Vec::new();
 
-    for (txid, reimbursement_info) in final_reimbursements {
+    for (deposit_idx, reimbursement_info) in final_reimbursements {
         let check_txid = match reimbursement_info.status {
-            ReimbursementStatus::Cancelled => reimbursement_info.claim_txid,
+            ReimbursementStatus::Slashed | ReimbursementStatus::Aborted => {
+                reimbursement_info.claim_txid
+            }
             ReimbursementStatus::Complete => reimbursement_info
                 .payout_txid
                 .unwrap_or(reimbursement_info.claim_txid),
-            ReimbursementStatus::Challenged
-            | ReimbursementStatus::InProgress
-            | ReimbursementStatus::NotStarted => unreachable!(),
+            ReimbursementStatus::InProgress | ReimbursementStatus::NotStarted => continue,
         };
 
         let current_confirmations =
@@ -108,7 +81,7 @@ async fn determine_reimbursements_to_purge(
 
         if let Some(confirmations) = current_confirmations {
             if confirmations >= max_confirmations {
-                reimbursements_to_purge.push(txid);
+                reimbursements_to_purge.push(deposit_idx);
             }
         }
     }
@@ -116,7 +89,7 @@ async fn determine_reimbursements_to_purge(
     reimbursements_to_purge
 }
 
-/// Periodically fetch bridge status and update bridge cache
+/// Periodically fetch bridge status and update bridge cache.
 pub async fn bridge_monitoring_task(
     context: Arc<BridgeMonitoringContext>,
     shutdown: ShutdownGuard,
@@ -125,7 +98,6 @@ pub async fn bridge_monitoring_task(
         context.config().status_refetch_interval(),
     ));
 
-    // Create RPC client manager once and reuse it
     let rpc_manager = RpcClientManager::new(context.config());
     let esplora_client = esplora::EsploraClient::new(
         context.config().esplora_url(),
@@ -138,9 +110,6 @@ pub async fn bridge_monitoring_task(
             _ = interval.tick() => {}
         }
 
-        // Fetch all data without holding lock
-
-        // Bridge operator status
         let mut operator_statuses = Vec::new();
 
         for (index, operator) in context.config().operators().iter().enumerate() {
@@ -151,7 +120,6 @@ pub async fn bridge_monitoring_task(
             operator_statuses.push(OperatorStatus::new(operator_id, operator_pk, status));
         }
 
-        // Update operators incrementally
         context
             .with_state_mut(|cache| {
                 cache.update_operators(operator_statuses);
@@ -167,51 +135,27 @@ pub async fn bridge_monitoring_task(
         };
         info!(%chain_tip_height, "bitcoin chain tip");
 
-        // Get existing active entries from cache to avoid unnecessary RPC calls
-        let (active_deposits, active_withdrawals, active_reimbursements) = context
-            .with_state(|cache| {
-                let deposits: Vec<Txid> = cache
-                    .filter_deposits(|s| matches!(s, DepositStatus::InProgress))
-                    .iter()
-                    .map(|(txid, _)| *txid)
-                    .collect();
-                let withdrawals: Vec<Buf32> = cache
-                    .filter_withdrawals(|s| matches!(s, WithdrawalStatus::InProgress))
-                    .iter()
-                    .map(|(request_id, _)| *request_id)
-                    .collect();
-                let reimbursements: Vec<Txid> = cache
-                    .filter_reimbursements(|s| {
-                        matches!(
-                            s,
-                            ReimbursementStatus::InProgress | ReimbursementStatus::Challenged
-                        )
-                    })
-                    .iter()
-                    .map(|(txid, _)| *txid)
-                    .collect();
-                (deposits, withdrawals, reimbursements)
-            })
-            .await;
+        let deposit_indices = match bridge_rpc::get_deposit_indices(&rpc_manager).await {
+            Ok(indices) => indices,
+            Err(e) => {
+                error!(error = %e, "failed to fetch bridge deposit indices");
+                continue;
+            }
+        };
 
-        // Update deposits incrementally
-        let deposit_updates: Vec<(Txid, DepositInfo, u64)> = get_deposits(
+        let deposit_infos = get_deposits(
             &rpc_manager,
             context.config(),
             &esplora_client,
             chain_tip_height,
-            &active_deposits,
+            &deposit_indices,
         )
-        .await
-        .iter()
-        .map(|(info, confirmations)| (info.deposit_request_txid, *info, *confirmations))
-        .collect();
+        .await;
 
         let final_deposits = context
             .with_state_mut(|cache| {
-                cache.apply_deposit_updates(deposit_updates);
+                cache.apply_deposit_updates(deposit_infos);
 
-                // Determine deposits to purge after applying updates.
                 cache.filter_deposits(|s| {
                     matches!(s, DepositStatus::Complete | DepositStatus::Failed)
                 })
@@ -230,62 +174,36 @@ pub async fn bridge_monitoring_task(
             })
             .await;
 
-        // Update withdrawals incrementally
-        let withdrawal_updates: Vec<(Buf32, WithdrawalInfo, u64)> = get_withdrawals(
-            &rpc_manager,
-            context.config(),
-            &esplora_client,
-            chain_tip_height,
-            &active_withdrawals,
-        )
-        .await
-        .iter()
-        .map(|(info, confirmations)| (info.withdrawal_request_txid, *info, *confirmations))
-        .collect();
-
-        let final_withdrawals = context
-            .with_state_mut(|cache| {
-                cache.apply_withdrawal_updates(withdrawal_updates);
-
-                // Determine withdrawals to purge after applying updates.
-                cache.filter_withdrawals(|s| matches!(s, WithdrawalStatus::Complete))
-            })
-            .await;
-        let withdrawals_to_purge = determine_withdrawals_to_purge(
-            final_withdrawals,
-            context.config(),
-            &esplora_client,
-            chain_tip_height,
-        )
-        .await;
+        let withdrawal_updates = get_withdrawals().await;
         context
             .with_state_mut(|cache| {
-                cache.purge_withdrawals(withdrawals_to_purge);
+                cache.apply_withdrawal_updates(withdrawal_updates);
             })
             .await;
 
-        // Update reimbursements incrementally
-        let reimbursement_updates: Vec<(Txid, ReimbursementInfo, u64)> = get_reimbursements(
+        // Reimbursements are only possible after withdrawal fulfillment. This
+        // commit does not yet join deposit_idx to indexed withdrawal status, so
+        // there are no sound reimbursement candidates to query.
+        let reimbursement_deposit_indices = Vec::new();
+        let reimbursement_infos = get_reimbursements(
             &rpc_manager,
             context.config(),
             &esplora_client,
             chain_tip_height,
-            &active_reimbursements,
+            &reimbursement_deposit_indices,
         )
-        .await
-        .iter()
-        .map(|(info, confirmations)| (info.claim_txid, *info, *confirmations))
-        .collect();
+        .await;
 
         let final_reimbursements = context
             .with_state_mut(|cache| {
-                cache.apply_reimbursement_updates(reimbursement_updates);
+                cache.apply_reimbursement_updates(reimbursement_infos);
 
-                // Determine reimbursements to purge after applying updates.
                 cache.filter_reimbursements(|s| {
                     matches!(
                         s,
-                        ReimbursementStatus::Complete | ReimbursementStatus::Cancelled
+                        ReimbursementStatus::Complete
+                            | ReimbursementStatus::Slashed
+                            | ReimbursementStatus::Aborted
                     )
                 })
             })
@@ -303,87 +221,55 @@ pub async fn bridge_monitoring_task(
             })
             .await;
 
-        // Mark initial status query as complete and notify waiters
         context.mark_status_available();
     }
 
     Ok(())
 }
 
-/// Fetch detailed information for all deposit requests
-///
-/// Queries bridge operators for deposit details, including both new deposit requests
-/// and existing active deposits that need status updates. Filters results based on
-/// confirmation count to only include deposits below the maximum confirmation threshold.
-///
-/// # Arguments
-///
-/// * `rpc_manager` - RPC client manager with retry/failover logic
-/// * `config` - Bridge monitoring configuration (contains max confirmations threshold)
-/// * `chain_tip_height` - Current Bitcoin blockchain height
-/// * `active_deposit_txids` - List of deposit txids already being tracked (for status updates)
-///
-/// # Returns
-///
-/// Vector of tuples containing:
-///
-/// - [`DepositInfo`] - Detailed deposit information
-/// - [`u64`] - Number of confirmations (0 for in-progress deposits)
-///
-/// Deposits are filtered to only include those with confirmations < [`BridgeMonitoringConfig::max_tx_confirmations`].
+/// Fetch detailed information for all deposits.
 async fn get_deposits(
     rpc_manager: &RpcClientManager,
     config: &BridgeMonitoringConfig,
     esplora_client: &esplora::EsploraClient,
     chain_tip_height: L1Height,
-    active_deposit_txids: &[Txid],
-) -> Vec<(DepositInfo, u64)> {
-    let new_deposit_requests = bridge_rpc::get_deposit_requests(rpc_manager).await;
-    let new_count = new_deposit_requests.len();
-    let mut deposit_requests = new_deposit_requests;
-
-    // Add existing active deposits that we need to check for status updates
-    for txid in active_deposit_txids {
-        if !deposit_requests.contains(txid) {
-            deposit_requests.push(*txid);
-        }
-    }
-
+    deposit_indices: &[DepositIdx],
+) -> Vec<(DepositIdx, DepositInfo, u64)> {
     info!(
-        deposit_request_count = deposit_requests.len(),
-        new_deposit_request_count = new_count,
-        active_deposit_count = active_deposit_txids.len(),
-        "checking deposit requests"
+        deposit_count = deposit_indices.len(),
+        "fetching deposit details"
     );
 
-    let mut deposit_infos: Vec<(DepositInfo, u64)> = Vec::new();
-    for deposit_request_txid in deposit_requests.iter() {
-        let txid = *deposit_request_txid;
-        let rpc_info = bridge_rpc::get_deposit_request_info(rpc_manager, txid).await;
-
-        let Some(dep_info) = rpc_info else {
-            error!(%deposit_request_txid, "failed to fetch deposit info after retries");
-            continue;
+    let mut deposit_infos = Vec::new();
+    for deposit_idx in deposit_indices.iter().copied() {
+        let dep_info = match bridge_rpc::get_deposit_info(rpc_manager, deposit_idx).await {
+            Ok(info) => info,
+            Err(e) => {
+                error!(deposit_idx, error = %e, "failed to fetch deposit info");
+                continue;
+            }
         };
 
-        // Filter based on number of confirmations
         match &dep_info.status {
             RpcDepositStatus::InProgress => {
-                // Always include in-progress deposits - no need to check confirmations
-                deposit_infos.push((DepositInfo::from(&dep_info), 0));
+                deposit_infos.push((dep_info.deposit_idx, DepositInfo::from(&dep_info), 0));
             }
             RpcDepositStatus::Failed { .. } | RpcDepositStatus::Complete { .. } => {
                 let txid = match &dep_info.status {
                     RpcDepositStatus::Failed { .. } => dep_info.deposit_request_txid,
                     RpcDepositStatus::Complete { deposit_txid } => *deposit_txid,
-                    RpcDepositStatus::InProgress => unreachable!(), // Already matched
+                    RpcDepositStatus::InProgress => continue,
                 };
 
                 let confirmations =
                     esplora::get_tx_confirmations(esplora_client, txid, chain_tip_height).await;
                 if let Some(confirmations) = confirmations {
                     if confirmations < config.max_tx_confirmations() {
-                        deposit_infos.push((DepositInfo::from(&dep_info), confirmations));
+                        deposit_infos.push((
+                            dep_info.deposit_idx,
+                            DepositInfo::from(&dep_info),
+                            confirmations,
+                        ));
                     }
                 }
             }
@@ -396,183 +282,88 @@ async fn get_deposits(
     deposit_infos
 }
 
-/// Fetch detailed information for all withdrawal requests and fulfillments
+/// Return withdrawal updates for this stage of the deposit-indexed API migration.
 ///
-/// Queries bridge operators for withdrawal details, including both new withdrawal requests
-/// and existing active withdrawals that need status updates. Filters results based on
-/// confirmation count to only include withdrawals below the maximum confirmation threshold.
-///
-/// # Arguments
-///
-/// * `rpc_manager` - RPC client manager with retry/failover logic
-/// * `config` - Bridge monitoring configuration (contains max confirmations threshold)
-/// * `chain_tip_height` - Current Bitcoin blockchain height
-/// * `active_withdrawal_request_ids` - List of withdrawal request IDs already being tracked
-///
-/// # Returns
-///
-/// Vector of tuples containing:
-/// - `WithdrawalInfo` - Detailed withdrawal information
-/// - `u64` - Number of confirmations (0 for in-progress withdrawals)
-///
-/// Withdrawals are filtered to only include those with confirmations < max_tx_confirmations.
-async fn get_withdrawals(
-    rpc_manager: &RpcClientManager,
-    config: &BridgeMonitoringConfig,
-    esplora_client: &esplora::EsploraClient,
-    chain_tip_height: L1Height,
-    active_withdrawal_request_ids: &[Buf32],
-) -> Vec<(WithdrawalInfo, u64)> {
-    let new_withdrawal_requests = bridge_rpc::get_withdrawal_requests(rpc_manager).await;
-    let new_count = new_withdrawal_requests.len();
-    let mut withdrawal_requests = new_withdrawal_requests;
-
-    // Add existing active withdrawals that we need to check for status updates
-    for request_id in active_withdrawal_request_ids {
-        if !withdrawal_requests.contains(request_id) {
-            withdrawal_requests.push(*request_id);
-        }
-    }
-
-    info!(
-        withdrawal_request_count = withdrawal_requests.len(),
-        new_withdrawal_request_count = new_count,
-        active_withdrawal_count = active_withdrawal_request_ids.len(),
-        "checking withdrawal requests"
-    );
-
-    let mut withdrawal_infos: Vec<(WithdrawalInfo, u64)> = Vec::new();
-    for withdrawal_request_txid in withdrawal_requests.iter() {
-        let request_id = *withdrawal_request_txid;
-        let rpc_info = bridge_rpc::get_withdrawal_info(rpc_manager, request_id).await;
-
-        let Some(wd_info) = rpc_info else {
-            error!(%withdrawal_request_txid, "failed to fetch withdrawal info after retries");
-            continue;
-        };
-
-        // Filter based on number of confirmations
-        match &wd_info.status {
-            RpcWithdrawalStatus::InProgress => {
-                // Always include in-progress withdrawals
-                withdrawal_infos.push((WithdrawalInfo::from(&wd_info), 0));
-            }
-            RpcWithdrawalStatus::Complete { fulfillment_txid } => {
-                let confirmations = esplora::get_tx_confirmations(
-                    esplora_client,
-                    *fulfillment_txid,
-                    chain_tip_height,
-                )
-                .await;
-                if let Some(confirmations) = confirmations {
-                    if confirmations < config.max_tx_confirmations() {
-                        withdrawal_infos.push((WithdrawalInfo::from(&wd_info), confirmations));
-                    }
-                }
-            }
-        }
-    }
-
-    if withdrawal_infos.is_empty() {
-        warn!("no withdrawal infos found");
-    }
-    withdrawal_infos
+/// The bridge RPC is now keyed by `deposit_idx`, but the dashboard's frontend
+/// withdrawal row still requires the EE withdrawal request txid. Until the
+/// indexed WRT-to-deposit pairing is wired in, there are no sound withdrawal
+/// rows to emit.
+async fn get_withdrawals() -> Vec<(Buf32, WithdrawalInfo, u64)> {
+    Vec::new()
 }
 
-/// Fetch detailed information for all claim and reimbursement transactions
+/// Fetch bridge reimbursement status for completed withdrawals.
 ///
-/// Queries bridge operators for claim/reimbursement details, including both new claims
-/// and existing active reimbursements that need status updates. Filters results based on
-/// confirmation count and status (skips NotStarted claims).
-///
-/// # Arguments
-///
-/// * `rpc_manager` - RPC client manager with retry/failover logic
-/// * `config` - Bridge monitoring configuration (contains max confirmations threshold)
-/// * `chain_tip_height` - Current Bitcoin blockchain height
-/// * `active_reimbursement_txids` - List of claim txids already being tracked
-///
-/// # Returns
-///
-/// Vector of tuples containing:
-/// - `ReimbursementInfo` - Detailed claim/reimbursement information
-/// - `u64` - Number of confirmations (0 for in-progress/challenged claims)
-///
-/// Claims with status `NotStarted` are excluded. Completed/cancelled claims are filtered
-/// to only include those with confirmations < max_tx_confirmations.
+/// At strata-bridge `0ecec67b67db89f6b761ffeaa09af8e7ad864bb1`, the server
+/// returns `Ok(None)` for every `deposit_idx`; this loop produces no
+/// reimbursement rows until the upstream `get_reimbursement_status`
+/// implementation lands. The caller passes deposit indices whose withdrawals
+/// are known complete.
 async fn get_reimbursements(
     rpc_manager: &RpcClientManager,
     config: &BridgeMonitoringConfig,
     esplora_client: &esplora::EsploraClient,
     chain_tip_height: L1Height,
-    active_reimbursement_txids: &[Txid],
-) -> Vec<(ReimbursementInfo, u64)> {
-    let new_claims = bridge_rpc::get_claims(rpc_manager).await;
-    let new_count = new_claims.len();
-    let mut claims = new_claims;
-
-    // Add existing active reimbursements that we need to check for status updates
-    for txid in active_reimbursement_txids {
-        if !claims.contains(txid) {
-            claims.push(*txid);
-        }
-    }
-
-    info!(
-        claim_count = claims.len(),
-        new_claim_count = new_count,
-        active_reimbursement_count = active_reimbursement_txids.len(),
-        "checking claims"
-    );
-
+    deposit_indices: &[DepositIdx],
+) -> Vec<(DepositIdx, ReimbursementInfo, u64)> {
     let mut reimbursement_infos = Vec::new();
-    for claim_txid in claims.iter() {
-        let txid = *claim_txid;
-        let rpc_info = bridge_rpc::get_claim_info(rpc_manager, txid).await;
 
-        let Some(claim_info) = rpc_info else {
-            error!(%claim_txid, "failed to fetch claim info after retries");
+    for deposit_idx in deposit_indices.iter().copied() {
+        let status = match bridge_rpc::get_reimbursement_status(rpc_manager, deposit_idx).await {
+            Ok(status) => status,
+            Err(e) => {
+                warn!(deposit_idx, error = %e, "failed to fetch reimbursement status");
+                continue;
+            }
+        };
+        let Some(status) = status else {
             continue;
         };
 
-        // Filter based on number of confirmations
-        match &claim_info.status {
-            // Skip if not started
-            RpcReimbursementStatus::NotStarted => {
-                continue;
-            }
-            RpcReimbursementStatus::InProgress { .. }
-            | RpcReimbursementStatus::Challenged { .. } => {
-                // Always include in-progress or challenged claims - no need to check confirmations
-                reimbursement_infos.push((ReimbursementInfo::from(&claim_info), 0));
-            }
-            RpcReimbursementStatus::Cancelled | RpcReimbursementStatus::Complete { .. } => {
-                let txid = match &claim_info.status {
-                    RpcReimbursementStatus::Cancelled => claim_info.claim_txid,
-                    RpcReimbursementStatus::Complete { payout_txid } => *payout_txid,
-                    RpcReimbursementStatus::NotStarted
-                    | RpcReimbursementStatus::InProgress { .. }
-                    | RpcReimbursementStatus::Challenged { .. } => unreachable!(), // Already matched
-                };
-                let confirmations =
-                    esplora::get_tx_confirmations(esplora_client, txid, chain_tip_height).await;
+        let Some(info) = ReimbursementInfo::from_status(&status) else {
+            continue;
+        };
+
+        match info.status {
+            ReimbursementStatus::InProgress => reimbursement_infos.push((deposit_idx, info, 0)),
+            ReimbursementStatus::Slashed | ReimbursementStatus::Aborted => {
+                let confirmations = esplora::get_tx_confirmations(
+                    esplora_client,
+                    info.claim_txid,
+                    chain_tip_height,
+                )
+                .await;
                 if let Some(confirmations) = confirmations {
                     if confirmations < config.max_tx_confirmations() {
-                        reimbursement_infos
-                            .push((ReimbursementInfo::from(&claim_info), confirmations));
+                        reimbursement_infos.push((deposit_idx, info, confirmations));
                     }
                 }
             }
+            ReimbursementStatus::Complete => {
+                let Some(payout_txid) = info.payout_txid else {
+                    continue;
+                };
+                let confirmations =
+                    esplora::get_tx_confirmations(esplora_client, payout_txid, chain_tip_height)
+                        .await;
+                if let Some(confirmations) = confirmations {
+                    if confirmations < config.max_tx_confirmations() {
+                        reimbursement_infos.push((deposit_idx, info, confirmations));
+                    }
+                }
+            }
+            ReimbursementStatus::NotStarted => continue,
         }
     }
 
     if reimbursement_infos.is_empty() {
         warn!("no reimbursement infos found");
     }
+
     reimbursement_infos
 }
 
-/// Return latest bridge status extracted from cache
+/// Return latest bridge status extracted from cache.
 pub async fn get_bridge_status(context: Arc<BridgeMonitoringContext>) -> Json<BridgeStatus> {
     context.wait_until_status_available().await;
 

--- a/backend/crates/bridge/src/status.rs
+++ b/backend/crates/bridge/src/status.rs
@@ -120,11 +120,7 @@ pub async fn bridge_monitoring_task(
             operator_statuses.push(OperatorStatus::new(operator_id, operator_pk, status));
         }
 
-        context
-            .with_state_mut(|cache| {
-                cache.update_operators(operator_statuses);
-            })
-            .await;
+        context.state().update_operators(operator_statuses).await;
 
         let chain_tip_height = match esplora::get_bitcoin_chain_tip_height(&esplora_client).await {
             Ok(height) => height,
@@ -152,15 +148,7 @@ pub async fn bridge_monitoring_task(
         )
         .await;
 
-        let final_deposits = context
-            .with_state_mut(|cache| {
-                cache.apply_deposit_updates(deposit_infos);
-
-                cache.filter_deposits(|s| {
-                    matches!(s, DepositStatus::Complete | DepositStatus::Failed)
-                })
-            })
-            .await;
+        let final_deposits = context.state().apply_deposit_updates(deposit_infos).await;
         let deposits_to_purge = determine_deposits_to_purge(
             final_deposits,
             context.config(),
@@ -168,17 +156,12 @@ pub async fn bridge_monitoring_task(
             chain_tip_height,
         )
         .await;
-        context
-            .with_state_mut(|cache| {
-                cache.purge_deposits(deposits_to_purge);
-            })
-            .await;
+        context.state().purge_deposits(deposits_to_purge).await;
 
         let withdrawal_updates = get_withdrawals().await;
         context
-            .with_state_mut(|cache| {
-                cache.apply_withdrawal_updates(withdrawal_updates);
-            })
+            .state()
+            .apply_withdrawal_updates(withdrawal_updates)
             .await;
 
         // Reimbursements are only possible after withdrawal fulfillment. This
@@ -195,18 +178,8 @@ pub async fn bridge_monitoring_task(
         .await;
 
         let final_reimbursements = context
-            .with_state_mut(|cache| {
-                cache.apply_reimbursement_updates(reimbursement_infos);
-
-                cache.filter_reimbursements(|s| {
-                    matches!(
-                        s,
-                        ReimbursementStatus::Complete
-                            | ReimbursementStatus::Slashed
-                            | ReimbursementStatus::Aborted
-                    )
-                })
-            })
+            .state()
+            .apply_reimbursement_updates(reimbursement_infos)
             .await;
         let reimbursements_to_purge = determine_reimbursements_to_purge(
             final_reimbursements,
@@ -216,9 +189,8 @@ pub async fn bridge_monitoring_task(
         )
         .await;
         context
-            .with_state_mut(|cache| {
-                cache.purge_reimbursements(reimbursements_to_purge);
-            })
+            .state()
+            .purge_reimbursements(reimbursements_to_purge)
             .await;
 
         context.mark_status_available();

--- a/backend/crates/bridge/src/status.rs
+++ b/backend/crates/bridge/src/status.rs
@@ -3,7 +3,6 @@ use axum::Json;
 use bitcoin::secp256k1::PublicKey;
 use std::{collections::BTreeSet, sync::Arc};
 use strata_bridge_primitives::types::DepositIdx;
-use strata_primitives::buf::Buf32;
 use strata_primitives::L1Height;
 use strata_tasks::ShutdownGuard;
 
@@ -14,9 +13,10 @@ use super::{
     state::DepositInfoUpdate,
     types::{
         BridgeStatus, DepositInfo, DepositStatus, OperatorStatus, ReimbursementInfo,
-        ReimbursementStatus, WithdrawalInfo,
+        ReimbursementStatus,
     },
-    withdrawal_requests,
+    withdrawal_requests::fetch_withdrawal_requests,
+    withdrawal_status::get_withdrawal_updates,
 };
 
 use tokio::time::{interval, Duration};
@@ -121,7 +121,7 @@ pub async fn bridge_monitoring_task(
         let pairing_cursor = context.state().withdrawal_pairing_cursor().await;
         let new_deposit_indices_count =
             count_deposit_indices_from(&deposit_indices, pairing_cursor.next_deposit_idx);
-        let withdrawal_requests = withdrawal_requests::fetch_withdrawal_requests(
+        let withdrawal_requests = fetch_withdrawal_requests(
             context.withdrawal_index(),
             pairing_cursor.next_withdrawal_seq,
             new_deposit_indices_count,
@@ -138,15 +138,23 @@ pub async fn bridge_monitoring_task(
             );
         }
 
-        let withdrawal_updates = get_withdrawals().await;
+        let withdrawal_candidates = context.state().select_withdrawal_status_candidates().await;
+        let withdrawal_updates = get_withdrawal_updates(
+            context.bridge_rpc(),
+            context.withdrawal_index(),
+            context.esplora(),
+            chain_tip_height,
+            &withdrawal_candidates,
+            context.config().withdrawal_pairing_batch_size(),
+        )
+        .await;
         context
             .state()
-            .apply_withdrawal_updates(withdrawal_updates)
+            .apply_withdrawal_updates(withdrawal_updates, context.config().max_tx_confirmations())
             .await;
 
-        // Reimbursements are only possible after withdrawal fulfillment. This
-        // commit does not yet join deposit_idx to indexed withdrawal status, so
-        // there are no sound reimbursement candidates to query.
+        // Reimbursement rendering is deferred until the next step wires a
+        // reimbursement scan cursor over completed withdrawal deposit indices.
         let reimbursement_deposit_indices = Vec::new();
         let reimbursement_infos = get_reimbursements(
             context.bridge_rpc(),
@@ -263,16 +271,6 @@ async fn get_deposit_info_updates(
     }
 
     updates
-}
-
-/// Return withdrawal updates for this stage of the deposit-indexed API migration.
-///
-/// The bridge RPC is now keyed by `deposit_idx`, but the dashboard's frontend
-/// withdrawal row still requires the EE withdrawal request txid. Until the
-/// indexed WRT-to-deposit pairing is wired in, there are no sound withdrawal
-/// rows to emit.
-async fn get_withdrawals() -> Vec<(Buf32, WithdrawalInfo, u64)> {
-    Vec::new()
 }
 
 /// Fetch bridge reimbursement status for completed withdrawals.

--- a/backend/crates/bridge/src/status.rs
+++ b/backend/crates/bridge/src/status.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use axum::http::StatusCode;
 use axum::Json;
 use bitcoin::{secp256k1::PublicKey, Txid};
 use std::{collections::BTreeSet, sync::Arc};
@@ -19,7 +20,7 @@ use super::{
     withdrawal_status::get_withdrawal_updates,
 };
 
-use tokio::time::{interval, Duration};
+use tokio::time::{interval, timeout, Duration};
 use tracing::{error, info, warn};
 
 /// Periodically fetch bridge status and update bridge cache.
@@ -283,10 +284,21 @@ fn terminal_reimbursement_txid(info: &ReimbursementInfo) -> Option<Txid> {
 }
 
 /// Return latest bridge status extracted from cache.
-pub async fn get_bridge_status(context: Arc<BridgeMonitoringContext>) -> Json<BridgeStatus> {
-    context.wait_until_status_available().await;
+pub async fn get_bridge_status(
+    context: Arc<BridgeMonitoringContext>,
+) -> std::result::Result<Json<BridgeStatus>, StatusCode> {
+    let initial_status_wait_timeout = context.initial_status_wait_timeout();
+    if timeout(
+        initial_status_wait_timeout,
+        context.wait_until_initial_status(),
+    )
+    .await
+    .is_err()
+    {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
 
-    Json(context.bridge_status().await)
+    Ok(Json(context.bridge_status().await))
 }
 
 #[cfg(test)]

--- a/backend/crates/bridge/src/status.rs
+++ b/backend/crates/bridge/src/status.rs
@@ -3,7 +3,6 @@ use axum::Json;
 use bitcoin::secp256k1::PublicKey;
 use std::sync::Arc;
 use strata_bridge_primitives::types::DepositIdx;
-use strata_bridge_rpc::types::RpcDepositStatus;
 use strata_primitives::buf::Buf32;
 use strata_primitives::L1Height;
 use strata_tasks::ShutdownGuard;
@@ -11,7 +10,8 @@ use strata_tasks::ShutdownGuard;
 use super::{
     bridge_rpc,
     context::BridgeMonitoringContext,
-    esplora,
+    esplora::{self, get_bitcoin_chain_tip_height, EsploraClient},
+    state::DepositInfoUpdate,
     types::{
         BridgeStatus, DepositInfo, DepositStatus, OperatorStatus, ReimbursementInfo,
         ReimbursementStatus, WithdrawalInfo,
@@ -23,43 +23,11 @@ use tracing::{error, info, warn};
 
 use status_config::BridgeMonitoringConfig;
 
-/// Determine which cached deposit entries should be purged.
-async fn determine_deposits_to_purge(
-    final_deposits: Vec<(DepositIdx, DepositInfo)>,
-    config: &BridgeMonitoringConfig,
-    esplora_client: &esplora::EsploraClient,
-    chain_tip_height: L1Height,
-) -> Vec<DepositIdx> {
-    let max_confirmations = config.max_tx_confirmations();
-    let mut deposits_to_purge = Vec::new();
-
-    for (deposit_idx, deposit_info) in final_deposits {
-        let check_txid = match deposit_info.status {
-            DepositStatus::Failed => deposit_info.deposit_request_txid,
-            DepositStatus::Complete => deposit_info
-                .deposit_txid
-                .unwrap_or(deposit_info.deposit_request_txid),
-            DepositStatus::InProgress => continue,
-        };
-
-        let current_confirmations =
-            esplora::get_tx_confirmations(esplora_client, check_txid, chain_tip_height).await;
-
-        if let Some(confirmations) = current_confirmations {
-            if confirmations >= max_confirmations {
-                deposits_to_purge.push(deposit_idx);
-            }
-        }
-    }
-
-    deposits_to_purge
-}
-
 /// Determine which cached reimbursement entries should be purged.
 async fn determine_reimbursements_to_purge(
     final_reimbursements: Vec<(DepositIdx, ReimbursementInfo)>,
     config: &BridgeMonitoringConfig,
-    esplora_client: &esplora::EsploraClient,
+    esplora_client: &EsploraClient,
     chain_tip_height: L1Height,
 ) -> Vec<DepositIdx> {
     let max_confirmations = config.max_tx_confirmations();
@@ -117,8 +85,7 @@ pub async fn bridge_monitoring_task(
 
         context.state().update_operators(operator_statuses).await;
 
-        let chain_tip_height = match esplora::get_bitcoin_chain_tip_height(context.esplora()).await
-        {
+        let chain_tip_height = match get_bitcoin_chain_tip_height(context.esplora()).await {
             Ok(height) => height,
             Err(e) => {
                 error!(error = %e, "failed to get Bitcoin chain tip");
@@ -135,24 +102,20 @@ pub async fn bridge_monitoring_task(
             }
         };
 
-        let deposit_infos = get_deposits(
-            context.bridge_rpc(),
-            context.config(),
-            context.esplora(),
-            chain_tip_height,
-            &deposit_indices,
-        )
-        .await;
-
-        let final_deposits = context.state().apply_deposit_updates(deposit_infos).await;
-        let deposits_to_purge = determine_deposits_to_purge(
-            final_deposits,
-            context.config(),
-            context.esplora(),
-            chain_tip_height,
-        )
-        .await;
-        context.state().purge_deposits(deposits_to_purge).await;
+        let deposit_candidates = context
+            .state()
+            .select_deposit_info_candidates(&deposit_indices)
+            .await;
+        let deposit_infos = get_deposits(context.bridge_rpc(), &deposit_candidates).await;
+        let deposit_info_updates =
+            get_deposit_info_updates(context.esplora(), chain_tip_height, deposit_infos).await;
+        context
+            .state()
+            .apply_deposit_info_updates(
+                deposit_info_updates,
+                context.config().max_tx_confirmations(),
+            )
+            .await;
 
         let withdrawal_updates = get_withdrawals().await;
         context
@@ -198,11 +161,8 @@ pub async fn bridge_monitoring_task(
 /// Fetch detailed information for all deposits.
 async fn get_deposits(
     rpc_manager: &bridge_rpc::RpcClientManager,
-    config: &BridgeMonitoringConfig,
-    esplora_client: &esplora::EsploraClient,
-    chain_tip_height: L1Height,
     deposit_indices: &[DepositIdx],
-) -> Vec<(DepositIdx, DepositInfo, u64)> {
+) -> Vec<(DepositIdx, DepositInfo)> {
     info!(
         deposit_count = deposit_indices.len(),
         "fetching deposit details"
@@ -218,36 +178,48 @@ async fn get_deposits(
             }
         };
 
-        match &dep_info.status {
-            RpcDepositStatus::InProgress => {
-                deposit_infos.push((dep_info.deposit_idx, DepositInfo::from(&dep_info), 0));
-            }
-            RpcDepositStatus::Failed { .. } | RpcDepositStatus::Complete { .. } => {
-                let txid = match &dep_info.status {
-                    RpcDepositStatus::Failed { .. } => dep_info.deposit_request_txid,
-                    RpcDepositStatus::Complete { deposit_txid } => *deposit_txid,
-                    RpcDepositStatus::InProgress => continue,
-                };
-
-                let confirmations =
-                    esplora::get_tx_confirmations(esplora_client, txid, chain_tip_height).await;
-                if let Some(confirmations) = confirmations {
-                    if confirmations < config.max_tx_confirmations() {
-                        deposit_infos.push((
-                            dep_info.deposit_idx,
-                            DepositInfo::from(&dep_info),
-                            confirmations,
-                        ));
-                    }
-                }
-            }
-        }
+        deposit_infos.push((dep_info.deposit_idx, DepositInfo::from(&dep_info)));
     }
 
     if deposit_infos.is_empty() {
         warn!("no deposit infos found");
     }
     deposit_infos
+}
+
+async fn get_deposit_info_updates(
+    esplora_client: &EsploraClient,
+    chain_tip_height: L1Height,
+    deposit_infos: Vec<(DepositIdx, DepositInfo)>,
+) -> Vec<DepositInfoUpdate> {
+    let mut updates = Vec::new();
+
+    for (deposit_idx, deposit_info) in deposit_infos {
+        let check_txid = match deposit_info.status {
+            DepositStatus::InProgress => {
+                updates.push(DepositInfoUpdate {
+                    deposit_idx,
+                    info: deposit_info,
+                    confirmations: None,
+                });
+                continue;
+            }
+            DepositStatus::Failed => deposit_info.deposit_request_txid,
+            DepositStatus::Complete => deposit_info
+                .deposit_txid
+                .unwrap_or(deposit_info.deposit_request_txid),
+        };
+
+        let current_confirmations =
+            esplora::get_tx_confirmations(esplora_client, check_txid, chain_tip_height).await;
+        updates.push(DepositInfoUpdate {
+            deposit_idx,
+            info: deposit_info,
+            confirmations: current_confirmations,
+        });
+    }
+
+    updates
 }
 
 /// Return withdrawal updates for this stage of the deposit-indexed API migration.
@@ -270,7 +242,7 @@ async fn get_withdrawals() -> Vec<(Buf32, WithdrawalInfo, u64)> {
 async fn get_reimbursements(
     rpc_manager: &bridge_rpc::RpcClientManager,
     config: &BridgeMonitoringConfig,
-    esplora_client: &esplora::EsploraClient,
+    esplora_client: &EsploraClient,
     chain_tip_height: L1Height,
     deposit_indices: &[DepositIdx],
 ) -> Vec<(DepositIdx, ReimbursementInfo, u64)> {

--- a/backend/crates/bridge/src/types.rs
+++ b/backend/crates/bridge/src/types.rs
@@ -1,8 +1,7 @@
 use bitcoin::{secp256k1::PublicKey, Txid};
 use serde::{Deserialize, Serialize};
 use strata_bridge_rpc::types::{
-    RpcClaimInfo, RpcDepositInfo, RpcDepositStatus, RpcOperatorStatus, RpcReimbursementStatus,
-    RpcWithdrawalInfo, RpcWithdrawalStatus,
+    RpcClaimPhase, RpcDepositInfo, RpcDepositStatus, RpcOperatorStatus, RpcReimbursementStatus,
 };
 use strata_primitives::buf::Buf32;
 
@@ -32,7 +31,9 @@ impl OperatorStatus {
 pub(crate) enum DepositStatus {
     #[serde(rename = "In progress")]
     InProgress,
+
     Failed,
+
     Complete,
 }
 
@@ -71,6 +72,7 @@ impl From<&RpcDepositInfo> for DepositInfo {
 pub(crate) enum WithdrawalStatus {
     #[serde(rename = "In progress")]
     InProgress,
+
     Complete,
 }
 
@@ -82,47 +84,49 @@ pub(crate) struct WithdrawalInfo {
     pub(crate) status: WithdrawalStatus,
 }
 
-impl From<&RpcWithdrawalInfo> for WithdrawalInfo {
-    fn from(rpc_info: &RpcWithdrawalInfo) -> Self {
-        match &rpc_info.status {
-            RpcWithdrawalStatus::InProgress => Self {
-                withdrawal_request_txid: rpc_info.withdrawal_request_txid,
-                fulfillment_txid: None,
-                status: WithdrawalStatus::InProgress,
-            },
-            RpcWithdrawalStatus::Complete { fulfillment_txid } => Self {
-                withdrawal_request_txid: rpc_info.withdrawal_request_txid,
-                fulfillment_txid: Some(*fulfillment_txid),
-                status: WithdrawalStatus::Complete,
-            },
-        }
-    }
-}
-
 /// Reimbursement status
-#[derive(Serialize, Deserialize, Copy, Clone, Debug)]
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum ReimbursementStatus {
     #[serde(rename = "Not started")]
     NotStarted,
+
     #[serde(rename = "In progress")]
     InProgress,
-    Challenged,
-    Cancelled,
+
+    Slashed,
+
+    Aborted,
+
     Complete,
 }
 
 /// Challenge step for reimbursements
-#[derive(Serialize, Deserialize, Copy, Clone, Debug)]
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum ChallengeStep {
     #[serde(rename = "N/A")]
     NotApplicable,
-    Claim,
-    Challenge,
-    Assert,
+
+    Claimed,
+
+    Contested,
+
+    #[serde(rename = "Bridge proof posted")]
+    BridgeProofPosted,
+
+    #[serde(rename = "Bridge proof timed out")]
+    BridgeProofTimedout,
+
+    #[serde(rename = "Counter proof posted")]
+    CounterProofPosted,
+
+    #[serde(rename = "All NACKed")]
+    AllNackd,
+
+    Acked,
 }
 
 /// Claim and reimbursement information passed to status dashboard
-#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 pub(crate) struct ReimbursementInfo {
     pub(crate) claim_txid: Txid,
     pub(crate) challenge_step: ChallengeStep,
@@ -130,39 +134,51 @@ pub(crate) struct ReimbursementInfo {
     pub(crate) status: ReimbursementStatus,
 }
 
-impl From<&RpcClaimInfo> for ReimbursementInfo {
-    fn from(rpc_info: &RpcClaimInfo) -> Self {
-        match &rpc_info.status {
-            RpcReimbursementStatus::NotStarted => Self {
-                claim_txid: rpc_info.claim_txid,
-                challenge_step: ChallengeStep::NotApplicable,
-                payout_txid: None,
-                status: ReimbursementStatus::NotStarted,
-            },
-            RpcReimbursementStatus::InProgress { .. } => Self {
-                claim_txid: rpc_info.claim_txid,
-                challenge_step: ChallengeStep::Claim,
+impl ReimbursementInfo {
+    pub(crate) fn from_status(status: &RpcReimbursementStatus) -> Option<Self> {
+        match status {
+            RpcReimbursementStatus::NotStarted => None,
+            RpcReimbursementStatus::InProgress { claim_txid, phase } => Some(Self {
+                claim_txid: *claim_txid,
+                challenge_step: ChallengeStep::from(phase),
                 payout_txid: None,
                 status: ReimbursementStatus::InProgress,
-            },
-            RpcReimbursementStatus::Challenged { .. } => Self {
-                claim_txid: rpc_info.claim_txid,
-                challenge_step: ChallengeStep::Challenge,
-                payout_txid: None,
-                status: ReimbursementStatus::Challenged,
-            },
-            RpcReimbursementStatus::Cancelled => Self {
-                claim_txid: rpc_info.claim_txid,
+            }),
+            RpcReimbursementStatus::Slashed { claim_txid } => Some(Self {
+                claim_txid: *claim_txid,
                 challenge_step: ChallengeStep::NotApplicable,
                 payout_txid: None,
-                status: ReimbursementStatus::Cancelled,
-            },
-            RpcReimbursementStatus::Complete { payout_txid } => Self {
-                claim_txid: rpc_info.claim_txid,
+                status: ReimbursementStatus::Slashed,
+            }),
+            RpcReimbursementStatus::Aborted { claim_txid } => Some(Self {
+                claim_txid: *claim_txid,
+                challenge_step: ChallengeStep::NotApplicable,
+                payout_txid: None,
+                status: ReimbursementStatus::Aborted,
+            }),
+            RpcReimbursementStatus::Complete {
+                claim_txid,
+                payout_txid,
+            } => Some(Self {
+                claim_txid: *claim_txid,
                 challenge_step: ChallengeStep::NotApplicable,
                 payout_txid: Some(*payout_txid),
                 status: ReimbursementStatus::Complete,
-            },
+            }),
+        }
+    }
+}
+
+impl From<&RpcClaimPhase> for ChallengeStep {
+    fn from(value: &RpcClaimPhase) -> Self {
+        match value {
+            RpcClaimPhase::Claimed => Self::Claimed,
+            RpcClaimPhase::Contested => Self::Contested,
+            RpcClaimPhase::BridgeProofPosted => Self::BridgeProofPosted,
+            RpcClaimPhase::BridgeProofTimedout => Self::BridgeProofTimedout,
+            RpcClaimPhase::CounterProofPosted => Self::CounterProofPosted,
+            RpcClaimPhase::AllNackd => Self::AllNackd,
+            RpcClaimPhase::Acked => Self::Acked,
         }
     }
 }
@@ -173,4 +189,93 @@ pub struct BridgeStatus {
     pub(crate) deposits: Vec<DepositInfo>,
     pub(crate) withdrawals: Vec<WithdrawalInfo>,
     pub(crate) reimbursements: Vec<ReimbursementInfo>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::hashes::Hash;
+
+    fn txid(byte: u8) -> Txid {
+        Txid::from_byte_array([byte; 32])
+    }
+
+    #[test]
+    fn reimbursement_info_from_status_maps_all_variants() {
+        let claim_txid = txid(1);
+        let payout_txid = txid(2);
+
+        assert_eq!(
+            ReimbursementInfo::from_status(&RpcReimbursementStatus::NotStarted),
+            None
+        );
+        assert_eq!(
+            ReimbursementInfo::from_status(&RpcReimbursementStatus::InProgress {
+                claim_txid,
+                phase: RpcClaimPhase::BridgeProofPosted,
+            }),
+            Some(ReimbursementInfo {
+                claim_txid,
+                challenge_step: ChallengeStep::BridgeProofPosted,
+                payout_txid: None,
+                status: ReimbursementStatus::InProgress,
+            })
+        );
+        assert_eq!(
+            ReimbursementInfo::from_status(&RpcReimbursementStatus::Slashed { claim_txid }),
+            Some(ReimbursementInfo {
+                claim_txid,
+                challenge_step: ChallengeStep::NotApplicable,
+                payout_txid: None,
+                status: ReimbursementStatus::Slashed,
+            })
+        );
+        assert_eq!(
+            ReimbursementInfo::from_status(&RpcReimbursementStatus::Aborted { claim_txid }),
+            Some(ReimbursementInfo {
+                claim_txid,
+                challenge_step: ChallengeStep::NotApplicable,
+                payout_txid: None,
+                status: ReimbursementStatus::Aborted,
+            })
+        );
+        assert_eq!(
+            ReimbursementInfo::from_status(&RpcReimbursementStatus::Complete {
+                claim_txid,
+                payout_txid,
+            }),
+            Some(ReimbursementInfo {
+                claim_txid,
+                challenge_step: ChallengeStep::NotApplicable,
+                payout_txid: Some(payout_txid),
+                status: ReimbursementStatus::Complete,
+            })
+        );
+    }
+
+    #[test]
+    fn challenge_step_from_claim_phase_maps_all_variants() {
+        let cases = [
+            (RpcClaimPhase::Claimed, ChallengeStep::Claimed),
+            (RpcClaimPhase::Contested, ChallengeStep::Contested),
+            (
+                RpcClaimPhase::BridgeProofPosted,
+                ChallengeStep::BridgeProofPosted,
+            ),
+            (
+                RpcClaimPhase::BridgeProofTimedout,
+                ChallengeStep::BridgeProofTimedout,
+            ),
+            (
+                RpcClaimPhase::CounterProofPosted,
+                ChallengeStep::CounterProofPosted,
+            ),
+            (RpcClaimPhase::AllNackd, ChallengeStep::AllNackd),
+            (RpcClaimPhase::Acked, ChallengeStep::Acked),
+        ];
+
+        for (rpc_phase, expected_step) in cases {
+            assert_eq!(ChallengeStep::from(&rpc_phase), expected_step);
+        }
+    }
 }

--- a/backend/crates/bridge/src/types.rs
+++ b/backend/crates/bridge/src/types.rs
@@ -2,6 +2,7 @@ use bitcoin::{secp256k1::PublicKey, Txid};
 use serde::{Deserialize, Serialize};
 use strata_bridge_rpc::types::{
     RpcClaimPhase, RpcDepositInfo, RpcDepositStatus, RpcOperatorStatus, RpcReimbursementStatus,
+    RpcWithdrawalStatus,
 };
 use strata_primitives::buf::Buf32;
 
@@ -82,6 +83,26 @@ pub(crate) struct WithdrawalInfo {
     pub(crate) withdrawal_request_txid: Buf32,
     pub(crate) fulfillment_txid: Option<Txid>,
     pub(crate) status: WithdrawalStatus,
+}
+
+impl WithdrawalInfo {
+    pub(crate) fn from_status(
+        withdrawal_request_txid: Buf32,
+        status: &RpcWithdrawalStatus,
+    ) -> Self {
+        match status {
+            RpcWithdrawalStatus::InProgress => Self {
+                withdrawal_request_txid,
+                fulfillment_txid: None,
+                status: WithdrawalStatus::InProgress,
+            },
+            RpcWithdrawalStatus::Complete { fulfillment_txid } => Self {
+                withdrawal_request_txid,
+                fulfillment_txid: Some(*fulfillment_txid),
+                status: WithdrawalStatus::Complete,
+            },
+        }
+    }
 }
 
 /// Reimbursement status

--- a/backend/crates/bridge/src/withdrawal_indexer/task.rs
+++ b/backend/crates/bridge/src/withdrawal_indexer/task.rs
@@ -1,6 +1,6 @@
 //! Withdrawal indexer run loop.
 
-use std::{path::Path, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use alloy_sol_types::SolEvent;
 use alpen_reth_primitives::WithdrawalIntentEvent;
@@ -57,14 +57,10 @@ pub(crate) enum TickOutcome {
 /// Startup failures (DB open, RPC client) return an error so the caller
 /// can treat the task as critical. Tick errors are logged and retried.
 pub async fn run_withdrawal_indexer(
-    datadir: &Path,
+    db: Arc<WithdrawalIndexerDbSled>,
     cfg: WithdrawalIndexerConfig,
     shutdown: ShutdownGuard,
 ) -> Result<()> {
-    let db = Arc::new(
-        WithdrawalIndexerDbSled::open(datadir)
-            .map_err(|e| anyhow!("open withdrawal index DB under {}: {e}", datadir.display()))?,
-    );
     let rpc = JsonRpcEthClient::new(cfg.eth_rpc_url())
         .map_err(|e| anyhow!("construct EVM RPC client: {e}"))?;
     run_with_rpc(db, rpc, cfg, shutdown).await

--- a/backend/crates/bridge/src/withdrawal_indexer/task.rs
+++ b/backend/crates/bridge/src/withdrawal_indexer/task.rs
@@ -293,14 +293,9 @@ withdrawal_denomination_sats = 100000000
         )]);
         tick(&db, &rpc, &cfg()).await.expect("tick");
         assert_eq!(db.max_withdrawal_seq().expect("max"), Some(1));
-        let row0 = db
-            .get_withdrawal_request(0)
-            .expect("row 0")
-            .expect("present");
-        let row1 = db
-            .get_withdrawal_request(1)
-            .expect("row 1")
-            .expect("present");
+        let rows = db.fetch_withdrawal_requests_from(0, 2).expect("fetch rows");
+        let row0 = &rows[0].request;
+        let row1 = &rows[1].request;
         assert_eq!(row0.sub_idx, 0);
         assert_eq!(row1.sub_idx, 1);
         let state = db
@@ -354,18 +349,10 @@ withdrawal_denomination_sats = 100000000
 
         tick(&db, &rpc, &cfg()).await.expect("tick");
 
-        let seq0 = db
-            .get_withdrawal_request(0)
-            .expect("seq 0")
-            .expect("present");
-        let seq1 = db
-            .get_withdrawal_request(1)
-            .expect("seq 1")
-            .expect("present");
-        let seq2 = db
-            .get_withdrawal_request(2)
-            .expect("seq 2")
-            .expect("present");
+        let rows = db.fetch_withdrawal_requests_from(0, 3).expect("fetch rows");
+        let seq0 = &rows[0].request;
+        let seq1 = &rows[1].request;
+        let seq2 = &rows[2].request;
 
         assert_eq!(seq0.tx_hash.0, [0xBB; 32]);
         assert_eq!(seq0.block_number, 5);

--- a/backend/crates/bridge/src/withdrawal_requests.rs
+++ b/backend/crates/bridge/src/withdrawal_requests.rs
@@ -1,0 +1,41 @@
+use tracing::warn;
+
+use super::db::{traits::WithdrawalIndexerDb, types::DbWithdrawalRequestRow};
+
+pub(crate) fn fetch_withdrawal_requests(
+    withdrawal_index: &impl WithdrawalIndexerDb,
+    start_seq: u64,
+    fetch_count: usize,
+    batch_size: usize,
+) -> Vec<DbWithdrawalRequestRow> {
+    if fetch_count == 0 || batch_size == 0 {
+        return Vec::new();
+    }
+
+    let mut requests = Vec::new();
+    let mut next_seq = start_seq;
+
+    while requests.len() < fetch_count {
+        let limit = (fetch_count - requests.len()).min(batch_size);
+        match withdrawal_index.fetch_withdrawal_requests_from(next_seq, limit) {
+            Ok(batch) => {
+                if batch.is_empty() {
+                    break;
+                }
+
+                let Some(next) = batch.last().and_then(|row| row.seq.checked_add(1)) else {
+                    requests.extend(batch);
+                    break;
+                };
+                next_seq = next;
+                requests.extend(batch);
+            }
+            Err(e) => {
+                warn!(error = %e, "failed to fetch indexed withdrawal requests");
+                break;
+            }
+        }
+    }
+
+    requests
+}

--- a/backend/crates/bridge/src/withdrawal_requests.rs
+++ b/backend/crates/bridge/src/withdrawal_requests.rs
@@ -39,3 +39,37 @@ pub(crate) fn fetch_withdrawal_requests(
 
     requests
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{
+        types::DbWithdrawalRequest,
+        withdrawal_index::{mock::MockWithdrawalIndexerDb, test_utils::make_withdrawal_request},
+    };
+
+    #[test]
+    fn fetches_withdrawal_requests_in_batches() {
+        let db = MockWithdrawalIndexerDb::default();
+        let request = make_withdrawal_request(1);
+        db.insert_withdrawal_event(&[
+            request.clone(),
+            DbWithdrawalRequest {
+                sub_idx: 1,
+                ..request.clone()
+            },
+            DbWithdrawalRequest {
+                sub_idx: 2,
+                ..request
+            },
+        ])
+        .expect("insert requests");
+
+        let rows = fetch_withdrawal_requests(&db, 0, 3, 2);
+
+        assert_eq!(
+            rows.into_iter().map(|row| row.seq).collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+    }
+}

--- a/backend/crates/bridge/src/withdrawal_status.rs
+++ b/backend/crates/bridge/src/withdrawal_status.rs
@@ -1,0 +1,92 @@
+use std::collections::BTreeMap;
+
+use strata_primitives::L1Height;
+use tracing::warn;
+
+use super::{
+    bridge_rpc::{self, RpcClientManager},
+    db::traits::WithdrawalIndexerDb,
+    esplora::{self, EsploraClient},
+    state::{WithdrawalInfoUpdate, WithdrawalStatusCandidate},
+    types::{WithdrawalInfo, WithdrawalStatus},
+    withdrawal_requests,
+};
+
+/// Fetch withdrawal cache updates for paired deposits.
+///
+/// This function owns the source joins needed to render withdrawal rows:
+/// `deposit_idx -> withdrawal_seq -> DbWithdrawalRequest -> bridge status`.
+/// It takes source clients and DB handles, but never reads or mutates
+/// [`BridgeMonitoringState`](super::state::BridgeMonitoringState).
+pub(crate) async fn get_withdrawal_updates(
+    rpc_manager: &RpcClientManager,
+    withdrawal_index: &impl WithdrawalIndexerDb,
+    esplora_client: &EsploraClient,
+    chain_tip_height: L1Height,
+    candidates: &[WithdrawalStatusCandidate],
+    batch_size: usize,
+) -> Vec<WithdrawalInfoUpdate> {
+    let Some(first_candidate) = candidates.first() else {
+        return Vec::new();
+    };
+
+    // Candidates come from state's FIFO pairing map and are contiguous from the
+    // withdrawal-status cursor, so fetching `len` rows from the first seq gives
+    // the matching WRT rows for this status batch.
+    let withdrawal_requests = withdrawal_requests::fetch_withdrawal_requests(
+        withdrawal_index,
+        first_candidate.withdrawal_seq,
+        candidates.len(),
+        batch_size,
+    );
+    let withdrawal_requests = withdrawal_requests
+        .into_iter()
+        .map(|row| (row.seq, row.request))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut updates = Vec::new();
+    for candidate in candidates {
+        let Some(withdrawal_request) = withdrawal_requests.get(&candidate.withdrawal_seq) else {
+            warn!(
+                deposit_idx = candidate.deposit_idx,
+                withdrawal_seq = candidate.withdrawal_seq,
+                "missing indexed withdrawal request for paired deposit"
+            );
+            continue;
+        };
+
+        let status =
+            match bridge_rpc::get_withdrawal_status(rpc_manager, candidate.deposit_idx).await {
+                Ok(Some(status)) => status,
+                Ok(None) => continue,
+                Err(e) => {
+                    warn!(
+                        deposit_idx = candidate.deposit_idx,
+                        error = %e,
+                        "failed to fetch withdrawal status"
+                    );
+                    continue;
+                }
+            };
+
+        let info = WithdrawalInfo::from_status(withdrawal_request.tx_hash, &status);
+        let confirmations = match info.status {
+            WithdrawalStatus::InProgress => None,
+            WithdrawalStatus::Complete => {
+                let Some(fulfillment_txid) = info.fulfillment_txid else {
+                    continue;
+                };
+                esplora::get_tx_confirmations(esplora_client, fulfillment_txid, chain_tip_height)
+                    .await
+            }
+        };
+
+        updates.push(WithdrawalInfoUpdate {
+            deposit_idx: candidate.deposit_idx,
+            info,
+            confirmations,
+        });
+    }
+
+    updates
+}

--- a/backend/crates/config/src/lib.rs
+++ b/backend/crates/config/src/lib.rs
@@ -47,11 +47,23 @@ const DEFAULT_RETRY_POLICY_BASE: f64 = 1.5;
 /// Default timeout for Esplora HTTP requests in seconds.
 const DEFAULT_ESPLORA_REQUEST_TIMEOUT_S: u64 = 5;
 
+/// Default time a network status request waits for the first poll result.
+const DEFAULT_NETWORK_INITIAL_STATUS_WAIT_TIMEOUT_S: u64 = 5;
+
+/// Default time a bridge status request waits for the first poll result.
+const DEFAULT_BRIDGE_INITIAL_STATUS_WAIT_TIMEOUT_S: u64 = 30;
+
 /// Default indexed WRT rows to read per withdrawal-index DB request.
 const DEFAULT_WITHDRAWAL_PAIRING_BATCH_SIZE: usize = 1_000;
 
 fn default_esplora_request_timeout_s() -> u64 {
     DEFAULT_ESPLORA_REQUEST_TIMEOUT_S
+}
+fn default_network_initial_status_wait_timeout_s() -> u64 {
+    DEFAULT_NETWORK_INITIAL_STATUS_WAIT_TIMEOUT_S
+}
+fn default_bridge_initial_status_wait_timeout_s() -> u64 {
+    DEFAULT_BRIDGE_INITIAL_STATUS_WAIT_TIMEOUT_S
 }
 fn default_withdrawal_pairing_batch_size() -> usize {
     DEFAULT_WITHDRAWAL_PAIRING_BATCH_SIZE
@@ -77,6 +89,10 @@ pub struct NetworkMonitoringConfig {
 
     /// Network status refetch interval in seconds
     status_refetch_interval_s: u64,
+
+    /// Timeout for HTTP status requests waiting on the first poll result.
+    #[serde(default = "default_network_initial_status_wait_timeout_s")]
+    initial_status_wait_timeout_s: u64,
 }
 
 impl NetworkMonitoringConfig {
@@ -94,6 +110,10 @@ impl NetworkMonitoringConfig {
 
     pub fn status_refetch_interval(&self) -> u64 {
         self.status_refetch_interval_s
+    }
+
+    pub fn initial_status_wait_timeout_s(&self) -> u64 {
+        self.initial_status_wait_timeout_s
     }
 
     /// Retry policy for sequencer status queries
@@ -130,6 +150,10 @@ pub struct BridgeMonitoringConfig {
 
     /// Bridge status refetch interval in seconds
     status_refetch_interval_s: u64,
+
+    /// Timeout for HTTP status requests waiting on the first poll result.
+    #[serde(default = "default_bridge_initial_status_wait_timeout_s")]
+    initial_status_wait_timeout_s: u64,
 
     /// Indexed WRT rows to read per withdrawal-index DB request.
     #[serde(default = "default_withdrawal_pairing_batch_size")]
@@ -259,6 +283,10 @@ impl BridgeMonitoringConfig {
         self.status_refetch_interval_s
     }
 
+    pub fn initial_status_wait_timeout_s(&self) -> u64 {
+        self.initial_status_wait_timeout_s
+    }
+
     pub fn withdrawal_pairing_batch_size(&self) -> usize {
         self.withdrawal_pairing_batch_size
     }
@@ -343,12 +371,14 @@ bundler_url = "https://bundler.testnet.alpenlabs.io/health"
 retry_policy_max_retries = 5
 retry_policy_total_time_s = 60
 status_refetch_interval_s = 10
+initial_status_wait_timeout_s = 5
 
 [bridge]
 esplora_request_timeout_s = 5
 esplora_url = "https://esplora.testnet.alpenlabs.io"
 max_tx_confirmations = 6
 status_refetch_interval_s = 120
+initial_status_wait_timeout_s = 5
 
 [[bridge.operators]]
 public_key = "02deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
@@ -450,12 +480,14 @@ bundler_url = "https://bundler.example.com/health"
 retry_policy_max_retries = 3
 retry_policy_total_time_s = 30
 status_refetch_interval_s = 5
+initial_status_wait_timeout_s = 4
 
 [bridge]
 esplora_request_timeout_s = 9
 esplora_url = "https://esplora.example.com"
 max_tx_confirmations = 12
 status_refetch_interval_s = 60
+initial_status_wait_timeout_s = 7
 withdrawal_pairing_batch_size = 500
 
 [[bridge.operators]]
@@ -487,10 +519,12 @@ withdrawal_denomination_sats = 100000000
             "https://sequencer.example.com"
         );
         assert_eq!(config.network.status_refetch_interval(), 5);
+        assert_eq!(config.network.initial_status_wait_timeout_s(), 4);
         assert_eq!(config.bridge.esplora_url(), "https://esplora.example.com");
         assert_eq!(config.bridge.esplora_request_timeout_s(), 9);
         assert_eq!(config.bridge.max_tx_confirmations(), 12);
         assert_eq!(config.bridge.status_refetch_interval(), 60);
+        assert_eq!(config.bridge.initial_status_wait_timeout_s(), 7);
         assert_eq!(config.bridge.withdrawal_pairing_batch_size(), 500);
         assert_eq!(config.bridge.operators().len(), 2);
         assert_eq!(
@@ -558,6 +592,14 @@ eth_rpc_url = "https://rpc.example.com"
         assert_eq!(
             config.bridge().withdrawal_pairing_batch_size(),
             DEFAULT_WITHDRAWAL_PAIRING_BATCH_SIZE
+        );
+        assert_eq!(
+            config.network().initial_status_wait_timeout_s(),
+            DEFAULT_NETWORK_INITIAL_STATUS_WAIT_TIMEOUT_S
+        );
+        assert_eq!(
+            config.bridge().initial_status_wait_timeout_s(),
+            DEFAULT_BRIDGE_INITIAL_STATUS_WAIT_TIMEOUT_S
         );
         let indexer = config.withdrawal_indexer();
         assert_eq!(indexer.batch_size(), DEFAULT_ETH_LOGS_BATCH_SIZE);

--- a/backend/crates/config/src/lib.rs
+++ b/backend/crates/config/src/lib.rs
@@ -47,8 +47,14 @@ const DEFAULT_RETRY_POLICY_BASE: f64 = 1.5;
 /// Default timeout for Esplora HTTP requests in seconds.
 const DEFAULT_ESPLORA_REQUEST_TIMEOUT_S: u64 = 5;
 
+/// Default indexed WRT rows to read per withdrawal-index DB request.
+const DEFAULT_WITHDRAWAL_PAIRING_BATCH_SIZE: usize = 1_000;
+
 fn default_esplora_request_timeout_s() -> u64 {
     DEFAULT_ESPLORA_REQUEST_TIMEOUT_S
+}
+fn default_withdrawal_pairing_batch_size() -> usize {
+    DEFAULT_WITHDRAWAL_PAIRING_BATCH_SIZE
 }
 
 /// Configuration for network monitoring services
@@ -124,6 +130,10 @@ pub struct BridgeMonitoringConfig {
 
     /// Bridge status refetch interval in seconds
     status_refetch_interval_s: u64,
+
+    /// Indexed WRT rows to read per withdrawal-index DB request.
+    #[serde(default = "default_withdrawal_pairing_batch_size")]
+    withdrawal_pairing_batch_size: usize,
 
     /// Bridge operators
     operators: Vec<BridgeOperator>,
@@ -247,6 +257,10 @@ impl BridgeMonitoringConfig {
 
     pub fn status_refetch_interval(&self) -> u64 {
         self.status_refetch_interval_s
+    }
+
+    pub fn withdrawal_pairing_batch_size(&self) -> usize {
+        self.withdrawal_pairing_batch_size
     }
 
     pub fn operators(&self) -> &Vec<BridgeOperator> {
@@ -442,6 +456,7 @@ esplora_request_timeout_s = 9
 esplora_url = "https://esplora.example.com"
 max_tx_confirmations = 12
 status_refetch_interval_s = 60
+withdrawal_pairing_batch_size = 500
 
 [[bridge.operators]]
 public_key = "02deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
@@ -476,6 +491,7 @@ withdrawal_denomination_sats = 100000000
         assert_eq!(config.bridge.esplora_request_timeout_s(), 9);
         assert_eq!(config.bridge.max_tx_confirmations(), 12);
         assert_eq!(config.bridge.status_refetch_interval(), 60);
+        assert_eq!(config.bridge.withdrawal_pairing_batch_size(), 500);
         assert_eq!(config.bridge.operators().len(), 2);
         assert_eq!(
             config.bridge.operators()[0].public_key(),
@@ -538,6 +554,10 @@ eth_rpc_url = "https://rpc.example.com"
         assert_eq!(
             config.bridge().esplora_request_timeout_s(),
             DEFAULT_ESPLORA_REQUEST_TIMEOUT_S
+        );
+        assert_eq!(
+            config.bridge().withdrawal_pairing_batch_size(),
+            DEFAULT_WITHDRAWAL_PAIRING_BATCH_SIZE
         );
         let indexer = config.withdrawal_indexer();
         assert_eq!(indexer.batch_size(), DEFAULT_ETH_LOGS_BATCH_SIZE);

--- a/backend/crates/network/Cargo.toml
+++ b/backend/crates/network/Cargo.toml
@@ -19,3 +19,6 @@
   serde_json.workspace = true
   tokio.workspace      = true
   tracing.workspace    = true
+
+[dev-dependencies]
+  toml.workspace = true

--- a/backend/crates/network/src/status.rs
+++ b/backend/crates/network/src/status.rs
@@ -1,10 +1,11 @@
 use anyhow::Result;
+use axum::http::StatusCode;
 use axum::Json;
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::http_client::HttpClient;
 use std::sync::Arc;
 use strata_tasks::ShutdownGuard;
-use tokio::time::{interval, sleep, Duration};
+use tokio::time::{interval, sleep, timeout, Duration};
 use tracing::{error, info};
 
 use super::types::{NetworkMonitoringContext, NetworkStatus, Status};
@@ -104,8 +105,19 @@ pub async fn network_monitoring_task(
 }
 
 /// Handler to get the current network status
-pub async fn get_network_status(context: Arc<NetworkMonitoringContext>) -> Json<NetworkStatus> {
-    context.wait_until_status_available().await;
+pub async fn get_network_status(
+    context: Arc<NetworkMonitoringContext>,
+) -> std::result::Result<Json<NetworkStatus>, StatusCode> {
+    let initial_status_wait_timeout = context.initial_status_wait_timeout();
+    if timeout(
+        initial_status_wait_timeout,
+        context.wait_until_initial_status(),
+    )
+    .await
+    .is_err()
+    {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
 
-    Json(context.status().await)
+    Ok(Json(context.status().await))
 }

--- a/backend/crates/network/src/types.rs
+++ b/backend/crates/network/src/types.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::{Notify, RwLock};
-use tracing::debug;
+use tokio::time::Duration;
 
 use status_config::NetworkMonitoringConfig;
 
@@ -80,10 +80,68 @@ impl NetworkMonitoringContext {
         }
     }
 
-    pub(crate) async fn wait_until_status_available(&self) {
-        if !self.status_available.load(Ordering::Acquire) {
-            debug!("Waiting for initial network status query to complete");
-            self.initial_status_query_complete.notified().await;
+    pub(crate) fn initial_status_wait_timeout(&self) -> Duration {
+        Duration::from_secs(self.config.initial_status_wait_timeout_s().max(1))
+    }
+
+    pub(crate) async fn wait_until_initial_status(&self) {
+        if self.status_available.load(Ordering::Acquire) {
+            return;
         }
+
+        let notified = self.initial_status_query_complete.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+
+        if self.status_available.load(Ordering::Acquire) {
+            return;
+        }
+
+        notified.await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> NetworkMonitoringConfig {
+        toml::from_str(
+            r#"
+            sequencer_url = "http://localhost:8545"
+            rpc_url = "http://localhost:8546"
+            bundler_url = "http://localhost:3000/health"
+            retry_policy_max_retries = 1
+            retry_policy_total_time_s = 1
+            status_refetch_interval_s = 1
+            "#,
+        )
+        .expect("test config should deserialize")
+    }
+
+    #[tokio::test]
+    async fn wait_for_initial_status_times_out_when_unavailable() {
+        let context = NetworkMonitoringContext::new(test_config());
+
+        assert!(tokio::time::timeout(
+            Duration::from_millis(1),
+            context.wait_until_initial_status()
+        )
+        .await
+        .is_err());
+    }
+
+    #[tokio::test]
+    async fn wait_for_initial_status_returns_when_available() {
+        let context = NetworkMonitoringContext::new(test_config());
+
+        context.mark_status_available();
+
+        assert!(tokio::time::timeout(
+            Duration::from_millis(1),
+            context.wait_until_initial_status()
+        )
+        .await
+        .is_ok());
     }
 }

--- a/backend/example-config.toml
+++ b/backend/example-config.toml
@@ -17,10 +17,11 @@ datadir = "data"
 
 # Bridge monitoring configuration
 [bridge]
-  esplora_request_timeout_s = 5
-  esplora_url               = "https://esplora.testnet.alpenlabs.io"
-  max_tx_confirmations      = 6
-  status_refetch_interval_s = 120
+  esplora_request_timeout_s     = 5
+  esplora_url                   = "https://esplora.testnet.alpenlabs.io"
+  max_tx_confirmations          = 6
+  status_refetch_interval_s     = 120
+  withdrawal_pairing_batch_size = 1_000
 
   # Bridge operators configuration
   [[bridge.operators]]

--- a/backend/example-config.toml
+++ b/backend/example-config.toml
@@ -8,17 +8,19 @@ datadir = "data"
 
 # Network monitoring configuration
 [network]
-  bundler_url               = "https://bundler.testnet.alpenlabs.io/health"
-  retry_policy_max_retries  = 5
-  retry_policy_total_time_s = 60
-  rpc_url                   = "https://rpc.testnet.alpenlabs.io"
-  sequencer_url             = "https://rpc.testnet.alpenlabs.io"
-  status_refetch_interval_s = 10
+  bundler_url                   = "https://bundler.testnet.alpenlabs.io/health"
+  initial_status_wait_timeout_s = 30
+  retry_policy_max_retries      = 5
+  retry_policy_total_time_s     = 60
+  rpc_url                       = "https://rpc.testnet.alpenlabs.io"
+  sequencer_url                 = "https://rpc.testnet.alpenlabs.io"
+  status_refetch_interval_s     = 10
 
 # Bridge monitoring configuration
 [bridge]
   esplora_request_timeout_s     = 5
   esplora_url                   = "https://esplora.testnet.alpenlabs.io"
+  initial_status_wait_timeout_s = 5
   max_tx_confirmations          = 6
   status_refetch_interval_s     = 120
   withdrawal_pairing_batch_size = 1_000


### PR DESCRIPTION
## Description

Updates the bridge status backend to use the deposit-indexed bridge API and moves monitoring state behind `BridgeMonitoringState`.

Key changes:
- Adds explicit in-memory status state for display cache, scan cursors, and withdrawal-to-deposit pairings.
- Moves long-lived bridge RPC, Esplora, and withdrawal-index DB handles into the monitoring context.
- Keeps the withdrawal-index DB WRT-only by removing status/pairing ownership from the indexer DB.
- Pairs indexed WRT rows with deposit indices in FIFO order, then queries real withdrawal status rows.
- Adds reimbursement status polling from paired deposit indices, with confirmation-based retention/purge.
- Splits WRT fetch and withdrawal-status query helpers into focused modules.

## Notes

Status cursors and pairings are in-memory in this PR. Restart-safe status persistence remains deferred to [STR-3295](https://alpenlabs.atlassian.net/browse/STR-3295).

Fixes [STR-3336](https://alpenlabs.atlassian.net/browse/STR-3336)

This PR was created with help fro Codex and Claude Code.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- Added bridge readiness tests: `wait_for_initial_status_times_out_when_unavailable` and `wait_for_initial_status_returns_when_available`.
- Added network readiness tests for the same initial-status timeout behavior.
- Added bridge cache/state tests for deposit info, withdrawal status, and reimbursement cursor advancement over contiguous terminal prefixes.
- Added withdrawal pairing planner tests for deposit gaps, missing indexed WRT rows, and avoiding re-pairing old indices.
- Added state integration tests for atomic withdrawal pairing apply and withdrawal/reimbursement candidate selection from cursors.
- Added withdrawal request batch-fetch test: `fetches_withdrawal_requests_in_batches`.
- Added bridge status/type mapping tests for reimbursement status and claim phase conversion.
- Updated config tests to cover new monitoring defaults and getters, including `initial_status_wait_timeout_s`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 

[STR-3295]: https://alpenlabs.atlassian.net/browse/STR-3295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STR-3336]: https://alpenlabs.atlassian.net/browse/STR-3336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ