### PR TITLE
STR 3295 Persist status dashboard backend state in a sled DB

### DIFF
--- a/backend/bin/dashboard/src/main.rs
+++ b/backend/bin/dashboard/src/main.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use axum::{routing::get, Router};
 use status_bridge::{
     bridge_monitoring_task, get_bridge_status, run_withdrawal_indexer, BridgeMonitoringContext,
-    WithdrawalIndexerDbSled,
+    BridgeStatusDbSled, WithdrawalIndexerDbSled,
 };
 use status_config::Config;
 use status_network::{get_network_status, network_monitoring_task, NetworkMonitoringContext};
@@ -32,11 +32,13 @@ fn main() -> Result<()> {
     let executor = task_manager.create_executor();
 
     let withdrawal_index_db = Arc::new(WithdrawalIndexerDbSled::open(config.datadir())?);
+    let bridge_status_db = Arc::new(BridgeStatusDbSled::open(config.datadir())?);
     let network_context = Arc::new(NetworkMonitoringContext::new(config.network().clone()));
     let bridge_context = Arc::new(BridgeMonitoringContext::new(
         config.bridge().clone(),
         Arc::clone(&withdrawal_index_db),
-    ));
+        Arc::clone(&bridge_status_db),
+    )?);
 
     let cors = CorsLayer::new().allow_origin(Any);
     let app = Router::new()

--- a/backend/crates/bridge/src/cache.rs
+++ b/backend/crates/bridge/src/cache.rs
@@ -12,12 +12,12 @@ use super::types::{
 #[derive(Debug, Clone)]
 pub(crate) struct CacheEntry<T> {
     pub(crate) data: T,
-    pub(crate) confirmations: u64,
+    pub(crate) confirmations: Option<u64>,
     pub(crate) last_updated: u64,
 }
 
 impl<T> CacheEntry<T> {
-    pub(crate) fn new(data: T, confirmations: u64) -> Self {
+    pub(crate) fn new(data: T, confirmations: Option<u64>) -> Self {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
@@ -29,7 +29,7 @@ impl<T> CacheEntry<T> {
         }
     }
 
-    pub(crate) fn update(&mut self, data: T, confirmations: u64) {
+    pub(crate) fn update(&mut self, data: T, confirmations: Option<u64>) {
         self.data = data;
         self.confirmations = confirmations;
         self.last_updated = SystemTime::now()
@@ -115,7 +115,7 @@ impl BridgeStatusCache {
         &mut self,
         deposit_idx: DepositIdx,
         info: DepositInfo,
-        confirmations: u64,
+        confirmations: Option<u64>,
     ) {
         if let Some(entry) = self.deposits.get_mut(&deposit_idx) {
             entry.update(info, confirmations);
@@ -130,7 +130,7 @@ impl BridgeStatusCache {
         &mut self,
         deposit_idx: DepositIdx,
         info: WithdrawalInfo,
-        confirmations: u64,
+        confirmations: Option<u64>,
     ) {
         if let Some(entry) = self.withdrawals.get_mut(&deposit_idx) {
             entry.update(info, confirmations);
@@ -145,7 +145,7 @@ impl BridgeStatusCache {
         &mut self,
         deposit_idx: DepositIdx,
         info: ReimbursementInfo,
-        confirmations: u64,
+        confirmations: Option<u64>,
     ) {
         if let Some(entry) = self.reimbursements.get_mut(&deposit_idx) {
             entry.update(info, confirmations);
@@ -166,7 +166,10 @@ impl BridgeStatusCache {
     }
 
     /// Batch update deposits
-    pub(crate) fn apply_deposit_updates(&mut self, updates: Vec<(DepositIdx, DepositInfo, u64)>) {
+    pub(crate) fn apply_deposit_updates(
+        &mut self,
+        updates: Vec<(DepositIdx, DepositInfo, Option<u64>)>,
+    ) {
         for (deposit_idx, info, confirmations) in updates {
             self.update_deposit(deposit_idx, info, confirmations);
         }
@@ -175,7 +178,7 @@ impl BridgeStatusCache {
     /// Batch update withdrawals
     pub(crate) fn apply_withdrawal_updates(
         &mut self,
-        updates: Vec<(DepositIdx, WithdrawalInfo, u64)>,
+        updates: Vec<(DepositIdx, WithdrawalInfo, Option<u64>)>,
     ) {
         for (deposit_idx, info, confirmations) in updates {
             self.update_withdrawal(deposit_idx, info, confirmations);
@@ -185,7 +188,7 @@ impl BridgeStatusCache {
     /// Batch update reimbursements
     pub(crate) fn apply_reimbursement_updates(
         &mut self,
-        updates: Vec<(DepositIdx, ReimbursementInfo, u64)>,
+        updates: Vec<(DepositIdx, ReimbursementInfo, Option<u64>)>,
     ) {
         for (deposit_idx, info, confirmations) in updates {
             self.update_reimbursement(deposit_idx, info, confirmations);

--- a/backend/crates/bridge/src/cache.rs
+++ b/backend/crates/bridge/src/cache.rs
@@ -4,7 +4,8 @@ use strata_bridge_primitives::types::DepositIdx;
 
 use super::types::{
     DepositInfo, DepositStatus, OperatorStatus, ReimbursementInfo, ReimbursementStatus,
-    WithdrawalInfo, WithdrawalStatus,
+    ReimbursementStatusCursor, WithdrawalInfo, WithdrawalPairingCursor, WithdrawalSeq,
+    WithdrawalStatus, WithdrawalStatusCursor,
 };
 
 /// Cache entry with timestamp and confirmation tracking
@@ -38,30 +39,11 @@ impl<T> CacheEntry<T> {
     }
 }
 
-/// In-memory cursor for withdrawal-to-deposit pairing progress.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) struct WithdrawalPairingCursor {
-    pub(crate) next_deposit_idx: DepositIdx,
-    pub(crate) next_withdrawal_seq: u64,
-}
-
 /// In-memory withdrawal-to-deposit pairings and their FIFO cursor.
 #[derive(Debug, Default, Clone)]
 pub(crate) struct WithdrawalPairing {
-    pairings: BTreeMap<DepositIdx, u64>,
+    pairings: BTreeMap<DepositIdx, WithdrawalSeq>,
     cursor: WithdrawalPairingCursor,
-}
-
-/// In-memory cursor for bridge withdrawal status polling progress.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) struct WithdrawalStatusCursor {
-    pub(crate) next_deposit_idx: DepositIdx,
-}
-
-/// In-memory cursor for bridge reimbursement status polling progress.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) struct ReimbursementStatusCursor {
-    pub(crate) next_deposit_idx: DepositIdx,
 }
 
 /// In-memory cache for bridge monitoring data
@@ -93,7 +75,7 @@ impl BridgeStatusCache {
     pub(crate) fn withdrawal_pairings_from(
         &self,
         deposit_idx: DepositIdx,
-    ) -> Vec<(DepositIdx, u64)> {
+    ) -> Vec<(DepositIdx, WithdrawalSeq)> {
         self.withdrawal_pairing
             .pairings
             .range(deposit_idx..)
@@ -103,7 +85,7 @@ impl BridgeStatusCache {
 
     pub(crate) fn update_withdrawal_pairings(
         &mut self,
-        pairings: &[(DepositIdx, u64)],
+        pairings: &[(DepositIdx, WithdrawalSeq)],
         cursor: WithdrawalPairingCursor,
     ) {
         self.withdrawal_pairing

--- a/backend/crates/bridge/src/cache.rs
+++ b/backend/crates/bridge/src/cache.rs
@@ -94,6 +94,22 @@ impl BridgeStatusCache {
         self.withdrawal_pairing.cursor = cursor;
     }
 
+    pub(crate) fn purge_withdrawal_pairings_range(&mut self, start: DepositIdx, end: DepositIdx) {
+        if start >= end {
+            return;
+        }
+
+        let deposit_indices = self
+            .withdrawal_pairing
+            .pairings
+            .range(start..end)
+            .map(|(deposit_idx, _)| *deposit_idx)
+            .collect::<Vec<_>>();
+        for deposit_idx in deposit_indices {
+            self.withdrawal_pairing.pairings.remove(&deposit_idx);
+        }
+    }
+
     pub(crate) fn withdrawal_status_cursor(&self) -> WithdrawalStatusCursor {
         self.withdrawal_status_cursor
     }
@@ -239,6 +255,7 @@ impl BridgeStatusCache {
     }
 
     /// Purge specific withdrawal entries
+    #[expect(dead_code, reason = "wired into reimbursement persistence")]
     pub(crate) fn purge_withdrawals(&mut self, withdrawals_to_purge: Vec<DepositIdx>) {
         for deposit_idx in withdrawals_to_purge {
             self.withdrawals.remove(&deposit_idx);

--- a/backend/crates/bridge/src/cache.rs
+++ b/backend/crates/bridge/src/cache.rs
@@ -5,7 +5,7 @@ use strata_bridge_primitives::types::DepositIdx;
 use super::types::{
     DepositInfo, DepositStatus, OperatorStatus, ReimbursementInfo, ReimbursementStatus,
     ReimbursementStatusCursor, WithdrawalInfo, WithdrawalPairingCursor, WithdrawalSeq,
-    WithdrawalStatus, WithdrawalStatusCursor,
+    WithdrawalStatusCursor,
 };
 
 /// Cache entry with timestamp and confirmation tracking
@@ -223,14 +223,14 @@ impl BridgeStatusCache {
             .collect()
     }
 
-    /// Filter withdrawals based on status condition
+    /// Filter withdrawals based on deposit index and row value.
     pub(crate) fn filter_withdrawals<F>(&self, filter: F) -> Vec<(DepositIdx, WithdrawalInfo)>
     where
-        F: Fn(&WithdrawalStatus) -> bool,
+        F: Fn(DepositIdx, &WithdrawalInfo) -> bool,
     {
         self.withdrawals
             .iter()
-            .filter(|(_, entry)| filter(&entry.data.status))
+            .filter(|(deposit_idx, entry)| filter(**deposit_idx, &entry.data))
             .map(|(deposit_idx, entry)| (*deposit_idx, entry.data))
             .collect()
     }
@@ -255,7 +255,6 @@ impl BridgeStatusCache {
     }
 
     /// Purge specific withdrawal entries
-    #[expect(dead_code, reason = "wired into reimbursement persistence")]
     pub(crate) fn purge_withdrawals(&mut self, withdrawals_to_purge: Vec<DepositIdx>) {
         for deposit_idx in withdrawals_to_purge {
             self.withdrawals.remove(&deposit_idx);

--- a/backend/crates/bridge/src/cache.rs
+++ b/backend/crates/bridge/src/cache.rs
@@ -3,9 +3,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use strata_bridge_primitives::types::DepositIdx;
 
 use super::types::{
-    DepositInfo, DepositStatus, OperatorStatus, ReimbursementInfo, ReimbursementStatus,
-    ReimbursementStatusCursor, WithdrawalInfo, WithdrawalPairingCursor, WithdrawalSeq,
-    WithdrawalStatusCursor,
+    DepositInfo, OperatorStatus, ReimbursementInfo, ReimbursementStatusCursor, WithdrawalInfo,
+    WithdrawalPairingCursor, WithdrawalSeq, WithdrawalStatusCursor,
 };
 
 /// Cache entry with timestamp and confirmation tracking
@@ -211,38 +210,38 @@ impl BridgeStatusCache {
         }
     }
 
-    /// Filter deposits based on status condition
+    /// Filter deposits based on deposit index, row value, and confirmations.
     pub(crate) fn filter_deposits<F>(&self, filter: F) -> Vec<(DepositIdx, DepositInfo)>
     where
-        F: Fn(&DepositStatus) -> bool,
+        F: Fn(DepositIdx, &DepositInfo, Option<u64>) -> bool,
     {
         self.deposits
             .iter()
-            .filter(|(_, entry)| filter(&entry.data.status))
+            .filter(|(deposit_idx, entry)| filter(**deposit_idx, &entry.data, entry.confirmations))
             .map(|(deposit_idx, entry)| (*deposit_idx, entry.data))
             .collect()
     }
 
-    /// Filter withdrawals based on deposit index and row value.
+    /// Filter withdrawals based on deposit index, row value, and confirmations.
     pub(crate) fn filter_withdrawals<F>(&self, filter: F) -> Vec<(DepositIdx, WithdrawalInfo)>
     where
-        F: Fn(DepositIdx, &WithdrawalInfo) -> bool,
+        F: Fn(DepositIdx, &WithdrawalInfo, Option<u64>) -> bool,
     {
         self.withdrawals
             .iter()
-            .filter(|(deposit_idx, entry)| filter(**deposit_idx, &entry.data))
+            .filter(|(deposit_idx, entry)| filter(**deposit_idx, &entry.data, entry.confirmations))
             .map(|(deposit_idx, entry)| (*deposit_idx, entry.data))
             .collect()
     }
 
-    /// Filter reimbursements based on status condition
+    /// Filter reimbursements based on deposit index, row value, and confirmations.
     pub(crate) fn filter_reimbursements<F>(&self, filter: F) -> Vec<(DepositIdx, ReimbursementInfo)>
     where
-        F: Fn(&ReimbursementStatus) -> bool,
+        F: Fn(DepositIdx, &ReimbursementInfo, Option<u64>) -> bool,
     {
         self.reimbursements
             .iter()
-            .filter(|(_, entry)| filter(&entry.data.status))
+            .filter(|(deposit_idx, entry)| filter(**deposit_idx, &entry.data, entry.confirmations))
             .map(|(deposit_idx, entry)| (*deposit_idx, entry.data))
             .collect()
     }

--- a/backend/crates/bridge/src/context.rs
+++ b/backend/crates/bridge/src/context.rs
@@ -7,8 +7,11 @@ use tokio::sync::Notify;
 use tokio::time::Duration;
 
 use super::{
-    bridge_rpc::RpcClientManager, db::WithdrawalIndexerDbSled, esplora::EsploraClient,
-    state::BridgeMonitoringState, types::BridgeStatus,
+    bridge_rpc::RpcClientManager,
+    db::{traits::BridgeStatusDb, BridgeStatusDbSled, WithdrawalIndexerDbSled},
+    esplora::EsploraClient,
+    state::BridgeMonitoringState,
+    types::BridgeStatus,
 };
 use status_config::BridgeMonitoringConfig;
 
@@ -18,6 +21,11 @@ pub struct BridgeMonitoringContext {
     bridge_rpc: RpcClientManager,
     esplora_client: EsploraClient,
     withdrawal_index: Arc<WithdrawalIndexerDbSled>,
+    #[expect(
+        dead_code,
+        reason = "used when status updates persist in follow-up commits"
+    )]
+    status_db: Arc<BridgeStatusDbSled>,
     state: BridgeMonitoringState,
     status_available: AtomicBool,
     initial_status_query_complete: Notify,
@@ -27,20 +35,26 @@ impl BridgeMonitoringContext {
     pub fn new(
         config: BridgeMonitoringConfig,
         withdrawal_index: Arc<WithdrawalIndexerDbSled>,
-    ) -> Self {
+        status_db: Arc<BridgeStatusDbSled>,
+    ) -> anyhow::Result<Self> {
         let bridge_rpc = RpcClientManager::new(&config);
         let esplora_client =
             EsploraClient::new(config.esplora_url(), config.esplora_request_timeout_s());
+        let snapshot = status_db
+            .get_status_snapshot()
+            .map_err(|e| anyhow::anyhow!("hydrate bridge status state: {e}"))?;
+        let state = BridgeMonitoringState::from_snapshot(snapshot);
 
-        Self {
+        Ok(Self {
             config,
             bridge_rpc,
             esplora_client,
             withdrawal_index,
-            state: BridgeMonitoringState::default(),
+            status_db,
+            state,
             status_available: AtomicBool::new(false),
             initial_status_query_complete: Notify::new(),
-        }
+        })
     }
 
     pub(crate) fn config(&self) -> &BridgeMonitoringConfig {
@@ -124,7 +138,9 @@ mod tests {
     fn test_context() -> BridgeMonitoringContext {
         let withdrawal_index =
             Arc::new(WithdrawalIndexerDbSled::open_temporary().expect("open db"));
-        BridgeMonitoringContext::new(test_config(), withdrawal_index)
+        let status_db = Arc::new(BridgeStatusDbSled::open_temporary().expect("open status db"));
+        BridgeMonitoringContext::new(test_config(), withdrawal_index, status_db)
+            .expect("create bridge monitoring context")
     }
 
     #[tokio::test]

--- a/backend/crates/bridge/src/context.rs
+++ b/backend/crates/bridge/src/context.rs
@@ -21,10 +21,6 @@ pub struct BridgeMonitoringContext {
     bridge_rpc: RpcClientManager,
     esplora_client: EsploraClient,
     withdrawal_index: Arc<WithdrawalIndexerDbSled>,
-    #[expect(
-        dead_code,
-        reason = "used when status updates persist in follow-up commits"
-    )]
     status_db: Arc<BridgeStatusDbSled>,
     state: BridgeMonitoringState,
     status_available: AtomicBool,
@@ -71,6 +67,10 @@ impl BridgeMonitoringContext {
 
     pub(crate) fn withdrawal_index(&self) -> &WithdrawalIndexerDbSled {
         self.withdrawal_index.as_ref()
+    }
+
+    pub(crate) fn status_db(&self) -> &BridgeStatusDbSled {
+        self.status_db.as_ref()
     }
 
     pub(crate) fn state(&self) -> &BridgeMonitoringState {
@@ -156,6 +156,7 @@ mod tests {
         context
             .state()
             .apply_deposit_info_updates(
+                context.status_db(),
                 vec![DepositInfoUpdate {
                     deposit_idx: 0,
                     info: DepositInfo {
@@ -167,7 +168,8 @@ mod tests {
                 }],
                 6,
             )
-            .await;
+            .await
+            .expect("apply deposit update");
 
         let status = context.bridge_status().await;
 

--- a/backend/crates/bridge/src/context.rs
+++ b/backend/crates/bridge/src/context.rs
@@ -108,7 +108,9 @@ impl BridgeMonitoringContext {
     }
 
     pub(crate) async fn bridge_status(&self) -> BridgeStatus {
-        self.state.bridge_status().await
+        self.state
+            .bridge_status(self.config.max_tx_confirmations())
+            .await
     }
 }
 

--- a/backend/crates/bridge/src/db/mod.rs
+++ b/backend/crates/bridge/src/db/mod.rs
@@ -6,4 +6,5 @@ pub(crate) mod traits;
 pub(crate) mod types;
 pub(crate) mod withdrawal_index;
 
+pub use status::db::BridgeStatusDbSled;
 pub use withdrawal_index::db::WithdrawalIndexerDbSled;

--- a/backend/crates/bridge/src/db/mod.rs
+++ b/backend/crates/bridge/src/db/mod.rs
@@ -1,6 +1,7 @@
 //! Persistence for the bridge crate.
 
 pub(crate) mod error;
+pub(crate) mod status;
 pub(crate) mod traits;
 pub(crate) mod types;
 pub(crate) mod withdrawal_index;

--- a/backend/crates/bridge/src/db/status/db.rs
+++ b/backend/crates/bridge/src/db/status/db.rs
@@ -1,11 +1,3 @@
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "status DB is wired into the monitoring state in follow-up commits"
-    )
-)]
-
 use std::path::Path;
 
 use anyhow::Context;

--- a/backend/crates/bridge/src/db/status/db.rs
+++ b/backend/crates/bridge/src/db/status/db.rs
@@ -1,0 +1,372 @@
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "status DB is wired into the monitoring state in follow-up commits"
+    )
+)]
+
+use std::path::Path;
+
+use anyhow::Context;
+use strata_bridge_primitives::types::DepositIdx;
+use typed_sled::{SledDb, SledTree};
+
+use crate::{
+    db::{
+        error::{DbError, DbResult},
+        traits::BridgeStatusDb,
+        types::{DbBridgeStatusSnapshot, StatusCursors},
+    },
+    types::{
+        ReimbursementStatusCursor, WithdrawalInfo, WithdrawalPairingCursor, WithdrawalSeq,
+        WithdrawalStatusCursor,
+    },
+};
+
+use super::schema::{
+    DepositInfoCursorSchema, ReimbursementStatusCursorSchema, WithdrawalInfoSchema,
+    WithdrawalPairingCursorSchema, WithdrawalPairingSchema, WithdrawalStatusCursorSchema,
+};
+
+const CURSOR_CELL_KEY: u8 = 0;
+
+/// Sled-backed bridge-status database.
+#[derive(Debug)]
+pub struct BridgeStatusDbSled {
+    _db: SledDb,
+    withdrawals: SledTree<WithdrawalInfoSchema>,
+    withdrawal_pairings: SledTree<WithdrawalPairingSchema>,
+    deposit_info_cursor: SledTree<DepositInfoCursorSchema>,
+    withdrawal_pairing_cursor: SledTree<WithdrawalPairingCursorSchema>,
+    withdrawal_status_cursor: SledTree<WithdrawalStatusCursorSchema>,
+    reimbursement_status_cursor: SledTree<ReimbursementStatusCursorSchema>,
+}
+
+impl BridgeStatusDbSled {
+    /// Open the status database under `{datadir}/status`.
+    pub fn open(datadir: impl AsRef<Path>) -> anyhow::Result<Self> {
+        let path = datadir.as_ref().join("status");
+        std::fs::create_dir_all(&path)
+            .with_context(|| format!("create bridge status db dir {}", path.display()))?;
+        let sled_db = sled::open(&path)
+            .with_context(|| format!("open bridge status sled db at {}", path.display()))?;
+        // typed-sled codec errors are not Send + Sync, so anyhow::Context cannot preserve them.
+        Self::from_sled_db(sled_db)
+            .map_err(|e| anyhow::anyhow!("initialize bridge status trees: {e}"))
+    }
+
+    /// Open a temporary in-memory-like sled database deleted on drop.
+    #[cfg(test)]
+    pub fn open_temporary() -> anyhow::Result<Self> {
+        let sled_db = sled::Config::new()
+            .temporary(true)
+            .open()
+            .context("open temporary bridge status sled db")?;
+        // typed-sled codec errors are not Send + Sync, so anyhow::Context cannot preserve them.
+        Self::from_sled_db(sled_db)
+            .map_err(|e| anyhow::anyhow!("initialize temporary bridge status trees: {e}"))
+    }
+
+    fn from_sled_db(sled_db: sled::Db) -> DbResult<Self> {
+        let db = SledDb::new(sled_db)?;
+
+        Ok(Self {
+            withdrawals: db.get_tree::<WithdrawalInfoSchema>()?,
+            withdrawal_pairings: db.get_tree::<WithdrawalPairingSchema>()?,
+            deposit_info_cursor: db.get_tree::<DepositInfoCursorSchema>()?,
+            withdrawal_pairing_cursor: db.get_tree::<WithdrawalPairingCursorSchema>()?,
+            withdrawal_status_cursor: db.get_tree::<WithdrawalStatusCursorSchema>()?,
+            reimbursement_status_cursor: db.get_tree::<ReimbursementStatusCursorSchema>()?,
+            _db: db,
+        })
+    }
+
+    fn status_cursors(&self) -> DbResult<StatusCursors> {
+        Ok(StatusCursors {
+            deposit_info: self
+                .deposit_info_cursor
+                .get(&CURSOR_CELL_KEY)?
+                .unwrap_or_default(),
+            withdrawal_pairing: self
+                .withdrawal_pairing_cursor
+                .get(&CURSOR_CELL_KEY)?
+                .unwrap_or_default(),
+            withdrawal_status: self
+                .withdrawal_status_cursor
+                .get(&CURSOR_CELL_KEY)?
+                .unwrap_or_default(),
+            reimbursement_status: self
+                .reimbursement_status_cursor
+                .get(&CURSOR_CELL_KEY)?
+                .unwrap_or_default(),
+        })
+    }
+}
+
+impl BridgeStatusDb for BridgeStatusDbSled {
+    fn get_status_snapshot(&self) -> DbResult<DbBridgeStatusSnapshot> {
+        Ok(DbBridgeStatusSnapshot {
+            withdrawals: self
+                .withdrawals
+                .iter()
+                .map(|result| result.map_err(DbError::from))
+                .collect::<DbResult<_>>()?,
+            withdrawal_pairings: self
+                .withdrawal_pairings
+                .iter()
+                .map(|result| result.map_err(DbError::from))
+                .collect::<DbResult<_>>()?,
+            cursors: self.status_cursors()?,
+        })
+    }
+
+    fn put_withdrawal_info(&self, deposit_idx: DepositIdx, info: &WithdrawalInfo) -> DbResult<()> {
+        self.withdrawals.insert(&deposit_idx, info)?;
+        Ok(())
+    }
+
+    fn del_withdrawal_info(&self, deposit_idx: DepositIdx) -> DbResult<bool> {
+        Ok(self.withdrawals.take(&deposit_idx)?.is_some())
+    }
+
+    fn put_withdrawal_pairings(&self, pairings: &[(DepositIdx, WithdrawalSeq)]) -> DbResult<()> {
+        for (deposit_idx, withdrawal_seq) in pairings {
+            self.withdrawal_pairings
+                .insert(deposit_idx, withdrawal_seq)?;
+        }
+        Ok(())
+    }
+
+    fn del_withdrawal_pairings_range(&self, start: DepositIdx, end: DepositIdx) -> DbResult<()> {
+        if start >= end {
+            return Ok(());
+        }
+
+        let deposit_indices = self
+            .withdrawal_pairings
+            .range(start..end)?
+            .map(|result| {
+                result
+                    .map(|(deposit_idx, _)| deposit_idx)
+                    .map_err(DbError::from)
+            })
+            .collect::<DbResult<Vec<_>>>()?;
+        for deposit_idx in deposit_indices {
+            self.withdrawal_pairings.remove(&deposit_idx)?;
+        }
+        Ok(())
+    }
+
+    fn put_deposit_info_cursor(&self, cursor: DepositIdx) -> DbResult<()> {
+        self.deposit_info_cursor.insert(&CURSOR_CELL_KEY, &cursor)?;
+        Ok(())
+    }
+
+    fn put_withdrawal_pairing_cursor(&self, cursor: WithdrawalPairingCursor) -> DbResult<()> {
+        self.withdrawal_pairing_cursor
+            .insert(&CURSOR_CELL_KEY, &cursor)?;
+        Ok(())
+    }
+
+    fn put_withdrawal_status_cursor(&self, cursor: WithdrawalStatusCursor) -> DbResult<()> {
+        self.withdrawal_status_cursor
+            .insert(&CURSOR_CELL_KEY, &cursor)?;
+        Ok(())
+    }
+
+    fn put_reimbursement_status_cursor(&self, cursor: ReimbursementStatusCursor) -> DbResult<()> {
+        self.reimbursement_status_cursor
+            .insert(&CURSOR_CELL_KEY, &cursor)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use bitcoin::{hashes::Hash, Txid};
+    use strata_primitives::buf::Buf32;
+
+    use super::*;
+    use crate::{
+        db::status::mock::MockBridgeStatusDb,
+        types::{WithdrawalInfo, WithdrawalStatus},
+    };
+
+    fn txid(byte: u8) -> Txid {
+        Txid::from_byte_array([byte; 32])
+    }
+
+    fn make_unique_db_path(test_name: &str) -> PathBuf {
+        let now_nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("current time must be >= UNIX_EPOCH")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "bridge_status_db_{test_name}_{}_{}",
+            std::process::id(),
+            now_nanos
+        ))
+    }
+
+    fn withdrawal_info(byte: u8, status: WithdrawalStatus) -> WithdrawalInfo {
+        WithdrawalInfo {
+            withdrawal_request_txid: Buf32([byte; 32]),
+            fulfillment_txid: Some(txid(byte + 1)),
+            status,
+        }
+    }
+
+    fn assert_empty_snapshot(db: &impl BridgeStatusDb) {
+        let snapshot = db.get_status_snapshot().expect("snapshot");
+        assert!(snapshot.withdrawals.is_empty());
+        assert!(snapshot.withdrawal_pairings.is_empty());
+        assert_eq!(snapshot.cursors, StatusCursors::default());
+    }
+
+    fn assert_roundtrip(db: &impl BridgeStatusDb) {
+        let withdrawal = withdrawal_info(3, WithdrawalStatus::Complete);
+        let cursors = StatusCursors {
+            deposit_info: 11,
+            withdrawal_pairing: WithdrawalPairingCursor {
+                next_deposit_idx: 12,
+                next_withdrawal_seq: 13,
+            },
+            withdrawal_status: WithdrawalStatusCursor {
+                next_deposit_idx: 14,
+            },
+            reimbursement_status: ReimbursementStatusCursor {
+                next_deposit_idx: 15,
+            },
+        };
+
+        db.put_withdrawal_info(2, &withdrawal)
+            .expect("put withdrawal");
+        db.put_withdrawal_pairings(&[(1, 7), (2, 8)])
+            .expect("put pairings");
+        db.put_deposit_info_cursor(cursors.deposit_info)
+            .expect("put deposit cursor");
+        db.put_withdrawal_pairing_cursor(cursors.withdrawal_pairing)
+            .expect("put pairing cursor");
+        db.put_withdrawal_status_cursor(cursors.withdrawal_status)
+            .expect("put withdrawal cursor");
+        db.put_reimbursement_status_cursor(cursors.reimbursement_status)
+            .expect("put reimbursement cursor");
+
+        let snapshot = db.get_status_snapshot().expect("snapshot");
+        assert_eq!(snapshot.withdrawals.len(), 1);
+        assert_eq!(snapshot.withdrawals[0].0, 2);
+        assert_eq!(
+            snapshot.withdrawals[0].1.withdrawal_request_txid,
+            Buf32([3; 32])
+        );
+        assert_eq!(snapshot.withdrawal_pairings, vec![(1, 7), (2, 8)]);
+        assert_eq!(snapshot.cursors, cursors);
+
+        db.del_withdrawal_pairings_range(0, 2)
+            .expect("del pairings range");
+        assert!(db.del_withdrawal_info(2).expect("del withdrawal"));
+        assert!(!db.del_withdrawal_info(2).expect("del missing withdrawal"));
+
+        let snapshot = db.get_status_snapshot().expect("snapshot after deletes");
+        assert!(snapshot.withdrawals.is_empty());
+        assert_eq!(snapshot.withdrawal_pairings, vec![(2, 8)]);
+        assert_eq!(snapshot.cursors, cursors);
+    }
+
+    fn assert_pairing_range_delete(db: &impl BridgeStatusDb) {
+        db.put_withdrawal_pairings(&[(1, 10), (2, 20), (4, 40), (5, 50)])
+            .expect("put pairings");
+
+        db.del_withdrawal_pairings_range(2, 5)
+            .expect("delete middle range");
+        assert_eq!(
+            db.get_status_snapshot()
+                .expect("snapshot")
+                .withdrawal_pairings,
+            vec![(1, 10), (5, 50)]
+        );
+
+        db.del_withdrawal_pairings_range(5, 5)
+            .expect("delete empty range");
+        db.del_withdrawal_pairings_range(6, 2)
+            .expect("delete reversed range");
+        assert_eq!(
+            db.get_status_snapshot()
+                .expect("snapshot")
+                .withdrawal_pairings,
+            vec![(1, 10), (5, 50)]
+        );
+    }
+
+    #[test]
+    fn status_db_empty_snapshot_sled() {
+        let db = BridgeStatusDbSled::open_temporary().expect("open db");
+        assert_empty_snapshot(&db);
+    }
+
+    #[test]
+    fn status_db_empty_snapshot_mock() {
+        assert_empty_snapshot(&MockBridgeStatusDb::default());
+    }
+
+    #[test]
+    fn status_db_roundtrip_sled() {
+        let db = BridgeStatusDbSled::open_temporary().expect("open db");
+        assert_roundtrip(&db);
+    }
+
+    #[test]
+    fn status_db_roundtrip_mock() {
+        assert_roundtrip(&MockBridgeStatusDb::default());
+    }
+
+    #[test]
+    fn status_db_pairing_range_delete_sled() {
+        let db = BridgeStatusDbSled::open_temporary().expect("open db");
+        assert_pairing_range_delete(&db);
+    }
+
+    #[test]
+    fn status_db_pairing_range_delete_mock() {
+        assert_pairing_range_delete(&MockBridgeStatusDb::default());
+    }
+
+    #[test]
+    fn status_rows_persist_across_reopen() {
+        let path = make_unique_db_path("reopen");
+        let withdrawal = withdrawal_info(9, WithdrawalStatus::Complete);
+        let cursor = StatusCursors {
+            deposit_info: 42,
+            ..StatusCursors::default()
+        };
+
+        {
+            let db = BridgeStatusDbSled::open(&path).expect("open db");
+            db.put_withdrawal_info(7, &withdrawal)
+                .expect("put withdrawal");
+            db.put_deposit_info_cursor(cursor.deposit_info)
+                .expect("put cursor");
+        }
+
+        {
+            let db = BridgeStatusDbSled::open(&path).expect("reopen db");
+            let snapshot = db.get_status_snapshot().expect("snapshot");
+            assert_eq!(snapshot.withdrawals.len(), 1);
+            assert_eq!(snapshot.withdrawals[0].0, 7);
+            assert_eq!(
+                snapshot.withdrawals[0].1.withdrawal_request_txid,
+                Buf32([9; 32])
+            );
+            assert_eq!(snapshot.cursors.deposit_info, cursor.deposit_info);
+        }
+
+        let _ = fs::remove_dir_all(path);
+    }
+}

--- a/backend/crates/bridge/src/db/status/mock.rs
+++ b/backend/crates/bridge/src/db/status/mock.rs
@@ -1,0 +1,142 @@
+use std::collections::BTreeMap;
+use std::sync::RwLock;
+
+use strata_bridge_primitives::types::DepositIdx;
+
+use crate::{
+    db::{
+        error::DbResult,
+        traits::BridgeStatusDb,
+        types::{DbBridgeStatusSnapshot, StatusCursors},
+    },
+    types::{
+        ReimbursementStatusCursor, WithdrawalInfo, WithdrawalPairingCursor, WithdrawalSeq,
+        WithdrawalStatusCursor,
+    },
+};
+
+/// In-memory bridge-status database for tests.
+#[derive(Debug, Default)]
+pub(crate) struct MockBridgeStatusDb {
+    withdrawals: RwLock<BTreeMap<DepositIdx, WithdrawalInfo>>,
+    withdrawal_pairings: RwLock<BTreeMap<DepositIdx, WithdrawalSeq>>,
+    deposit_info_cursor: RwLock<DepositIdx>,
+    withdrawal_pairing_cursor: RwLock<WithdrawalPairingCursor>,
+    withdrawal_status_cursor: RwLock<WithdrawalStatusCursor>,
+    reimbursement_status_cursor: RwLock<ReimbursementStatusCursor>,
+}
+
+impl BridgeStatusDb for MockBridgeStatusDb {
+    fn get_status_snapshot(&self) -> DbResult<DbBridgeStatusSnapshot> {
+        Ok(DbBridgeStatusSnapshot {
+            withdrawals: self
+                .withdrawals
+                .read()
+                .expect("mock withdrawals lock poisoned")
+                .iter()
+                .map(|(deposit_idx, info)| (*deposit_idx, *info))
+                .collect(),
+            withdrawal_pairings: self
+                .withdrawal_pairings
+                .read()
+                .expect("mock withdrawal_pairings lock poisoned")
+                .iter()
+                .map(|(deposit_idx, withdrawal_seq)| (*deposit_idx, *withdrawal_seq))
+                .collect(),
+            cursors: StatusCursors {
+                deposit_info: *self
+                    .deposit_info_cursor
+                    .read()
+                    .expect("mock deposit_info_cursor lock poisoned"),
+                withdrawal_pairing: *self
+                    .withdrawal_pairing_cursor
+                    .read()
+                    .expect("mock withdrawal_pairing_cursor lock poisoned"),
+                withdrawal_status: *self
+                    .withdrawal_status_cursor
+                    .read()
+                    .expect("mock withdrawal_status_cursor lock poisoned"),
+                reimbursement_status: *self
+                    .reimbursement_status_cursor
+                    .read()
+                    .expect("mock reimbursement_status_cursor lock poisoned"),
+            },
+        })
+    }
+
+    fn put_withdrawal_info(&self, deposit_idx: DepositIdx, info: &WithdrawalInfo) -> DbResult<()> {
+        self.withdrawals
+            .write()
+            .expect("mock withdrawals lock poisoned")
+            .insert(deposit_idx, *info);
+        Ok(())
+    }
+
+    fn del_withdrawal_info(&self, deposit_idx: DepositIdx) -> DbResult<bool> {
+        Ok(self
+            .withdrawals
+            .write()
+            .expect("mock withdrawals lock poisoned")
+            .remove(&deposit_idx)
+            .is_some())
+    }
+
+    fn put_withdrawal_pairings(&self, pairings: &[(DepositIdx, WithdrawalSeq)]) -> DbResult<()> {
+        self.withdrawal_pairings
+            .write()
+            .expect("mock withdrawal_pairings lock poisoned")
+            .extend(pairings.iter().copied());
+        Ok(())
+    }
+
+    fn del_withdrawal_pairings_range(&self, start: DepositIdx, end: DepositIdx) -> DbResult<()> {
+        if start >= end {
+            return Ok(());
+        }
+
+        let mut withdrawal_pairings = self
+            .withdrawal_pairings
+            .write()
+            .expect("mock withdrawal_pairings lock poisoned");
+        let deposit_indices = withdrawal_pairings
+            .range(start..end)
+            .map(|(deposit_idx, _)| *deposit_idx)
+            .collect::<Vec<_>>();
+        for deposit_idx in deposit_indices {
+            withdrawal_pairings.remove(&deposit_idx);
+        }
+        Ok(())
+    }
+
+    fn put_deposit_info_cursor(&self, cursor: DepositIdx) -> DbResult<()> {
+        *self
+            .deposit_info_cursor
+            .write()
+            .expect("mock deposit_info_cursor lock poisoned") = cursor;
+        Ok(())
+    }
+
+    fn put_withdrawal_pairing_cursor(&self, cursor: WithdrawalPairingCursor) -> DbResult<()> {
+        *self
+            .withdrawal_pairing_cursor
+            .write()
+            .expect("mock withdrawal_pairing_cursor lock poisoned") = cursor;
+        Ok(())
+    }
+
+    fn put_withdrawal_status_cursor(&self, cursor: WithdrawalStatusCursor) -> DbResult<()> {
+        *self
+            .withdrawal_status_cursor
+            .write()
+            .expect("mock withdrawal_status_cursor lock poisoned") = cursor;
+        Ok(())
+    }
+
+    fn put_reimbursement_status_cursor(&self, cursor: ReimbursementStatusCursor) -> DbResult<()> {
+        *self
+            .reimbursement_status_cursor
+            .write()
+            .expect("mock reimbursement_status_cursor lock poisoned") = cursor;
+        Ok(())
+    }
+}

--- a/backend/crates/bridge/src/db/status/mod.rs
+++ b/backend/crates/bridge/src/db/status/mod.rs
@@ -1,0 +1,7 @@
+//! Persistence for bridge-status rows, pairings, and cursors.
+
+pub(crate) mod db;
+pub(crate) mod schema;
+
+#[cfg(test)]
+pub(crate) mod mock;

--- a/backend/crates/bridge/src/db/status/schema.rs
+++ b/backend/crates/bridge/src/db/status/schema.rs
@@ -1,0 +1,107 @@
+//! Schema and codec definitions for the bridge-status DB trees.
+
+use typed_sled::{
+    codec::{CodecError, ValueCodec},
+    schema::TreeName,
+    Schema,
+};
+
+use strata_bridge_primitives::types::DepositIdx;
+
+use crate::types::{
+    ReimbursementStatusCursor, WithdrawalInfo, WithdrawalPairingCursor, WithdrawalSeq,
+    WithdrawalStatusCursor,
+};
+
+/// Withdrawal status rows keyed by bridge deposit index.
+#[derive(Debug)]
+pub(crate) struct WithdrawalInfoSchema;
+
+impl Schema for WithdrawalInfoSchema {
+    const TREE_NAME: TreeName = TreeName("withdrawal_info");
+    type Key = DepositIdx;
+    type Value = WithdrawalInfo;
+}
+
+/// Withdrawal-to-deposit pairing rows keyed by bridge deposit index.
+#[derive(Debug)]
+pub(crate) struct WithdrawalPairingSchema;
+
+impl Schema for WithdrawalPairingSchema {
+    const TREE_NAME: TreeName = TreeName("withdrawal_pairing");
+    type Key = DepositIdx;
+    type Value = WithdrawalSeq;
+}
+
+/// Deposit-info cursor cell.
+#[derive(Debug)]
+pub(crate) struct DepositInfoCursorSchema;
+
+impl Schema for DepositInfoCursorSchema {
+    const TREE_NAME: TreeName = TreeName("deposit_info_cursor");
+    type Key = u8;
+    type Value = DepositIdx;
+}
+
+/// Withdrawal-pairing cursor cell.
+#[derive(Debug)]
+pub(crate) struct WithdrawalPairingCursorSchema;
+
+impl Schema for WithdrawalPairingCursorSchema {
+    const TREE_NAME: TreeName = TreeName("withdrawal_pairing_cursor");
+    type Key = u8;
+    type Value = WithdrawalPairingCursor;
+}
+
+/// Withdrawal-status cursor cell.
+#[derive(Debug)]
+pub(crate) struct WithdrawalStatusCursorSchema;
+
+impl Schema for WithdrawalStatusCursorSchema {
+    const TREE_NAME: TreeName = TreeName("withdrawal_status_cursor");
+    type Key = u8;
+    type Value = WithdrawalStatusCursor;
+}
+
+/// Reimbursement-status cursor cell.
+#[derive(Debug)]
+pub(crate) struct ReimbursementStatusCursorSchema;
+
+impl Schema for ReimbursementStatusCursorSchema {
+    const TREE_NAME: TreeName = TreeName("reimbursement_status_cursor");
+    type Key = u8;
+    type Value = ReimbursementStatusCursor;
+}
+
+// ---- Value codecs ----
+
+macro_rules! impl_json_value_codec {
+    ($schema:ty, $value:ty) => {
+        impl ValueCodec<$schema> for $value {
+            type Decoded = Self;
+
+            fn encode_value(&self) -> Result<Vec<u8>, CodecError> {
+                serde_json::to_vec(self).map_err(|e| CodecError::SerializationFailed {
+                    schema: <$schema>::TREE_NAME.0,
+                    source: e.into(),
+                })
+            }
+
+            fn decode_value(data: sled::IVec) -> Result<Self::Decoded, CodecError> {
+                serde_json::from_slice(data.as_ref()).map_err(|e| {
+                    CodecError::DeserializationFailed {
+                        schema: <$schema>::TREE_NAME.0,
+                        source: e.into(),
+                    }
+                })
+            }
+        }
+    };
+}
+
+impl_json_value_codec!(WithdrawalInfoSchema, WithdrawalInfo);
+impl_json_value_codec!(WithdrawalPairingSchema, WithdrawalSeq);
+impl_json_value_codec!(DepositInfoCursorSchema, DepositIdx);
+impl_json_value_codec!(WithdrawalPairingCursorSchema, WithdrawalPairingCursor);
+impl_json_value_codec!(WithdrawalStatusCursorSchema, WithdrawalStatusCursor);
+impl_json_value_codec!(ReimbursementStatusCursorSchema, ReimbursementStatusCursor);

--- a/backend/crates/bridge/src/db/traits.rs
+++ b/backend/crates/bridge/src/db/traits.rs
@@ -54,10 +54,6 @@ pub(crate) trait BridgeStatusDb: Send + Sync {
     fn get_status_snapshot(&self) -> DbResult<DbBridgeStatusSnapshot>;
 
     /// Inserts or replaces one withdrawal status row.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired into state in follow-up commits")
-    )]
     fn put_withdrawal_info(&self, deposit_idx: DepositIdx, info: &WithdrawalInfo) -> DbResult<()>;
 
     /// Deletes one withdrawal status row.
@@ -71,10 +67,6 @@ pub(crate) trait BridgeStatusDb: Send + Sync {
     fn put_withdrawal_pairings(&self, pairings: &[(DepositIdx, WithdrawalSeq)]) -> DbResult<()>;
 
     /// Deletes withdrawal-to-deposit pairing rows in `start..end`.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired into state in follow-up commits")
-    )]
     fn del_withdrawal_pairings_range(&self, start: DepositIdx, end: DepositIdx) -> DbResult<()>;
 
     /// Stores the deposit-info polling cursor.
@@ -84,10 +76,6 @@ pub(crate) trait BridgeStatusDb: Send + Sync {
     fn put_withdrawal_pairing_cursor(&self, cursor: WithdrawalPairingCursor) -> DbResult<()>;
 
     /// Stores the withdrawal-status polling cursor.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired into state in follow-up commits")
-    )]
     fn put_withdrawal_status_cursor(&self, cursor: WithdrawalStatusCursor) -> DbResult<()>;
 
     /// Stores the reimbursement-status polling cursor.

--- a/backend/crates/bridge/src/db/traits.rs
+++ b/backend/crates/bridge/src/db/traits.rs
@@ -1,6 +1,17 @@
-use crate::db::{
-    error::DbResult,
-    types::{DbIndexerState, DbWithdrawalEventIndex, DbWithdrawalRequest, DbWithdrawalRequestRow},
+use strata_bridge_primitives::types::DepositIdx;
+
+use crate::{
+    db::{
+        error::DbResult,
+        types::{
+            DbBridgeStatusSnapshot, DbIndexerState, DbWithdrawalEventIndex, DbWithdrawalRequest,
+            DbWithdrawalRequestRow,
+        },
+    },
+    types::{
+        ReimbursementStatusCursor, WithdrawalInfo, WithdrawalPairingCursor, WithdrawalSeq,
+        WithdrawalStatusCursor,
+    },
 };
 
 /// Storage contract for indexed EVM withdrawal-intent events.
@@ -35,4 +46,41 @@ pub(crate) trait WithdrawalIndexerDb: Send + Sync {
 
     /// Returns the largest indexed withdrawal sequence number.
     fn max_withdrawal_seq(&self) -> DbResult<Option<u64>>;
+}
+
+/// Storage contract for bridge status rows, pairings, and cursors.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "status DB trait is consumed when persistence is wired into state"
+    )
+)]
+pub(crate) trait BridgeStatusDb: Send + Sync {
+    /// Loads all persisted status rows, pairings, and cursors.
+    fn get_status_snapshot(&self) -> DbResult<DbBridgeStatusSnapshot>;
+
+    /// Inserts or replaces one withdrawal status row.
+    fn put_withdrawal_info(&self, deposit_idx: DepositIdx, info: &WithdrawalInfo) -> DbResult<()>;
+
+    /// Deletes one withdrawal status row.
+    fn del_withdrawal_info(&self, deposit_idx: DepositIdx) -> DbResult<bool>;
+
+    /// Inserts or replaces withdrawal-to-deposit pairings.
+    fn put_withdrawal_pairings(&self, pairings: &[(DepositIdx, WithdrawalSeq)]) -> DbResult<()>;
+
+    /// Deletes withdrawal-to-deposit pairing rows in `start..end`.
+    fn del_withdrawal_pairings_range(&self, start: DepositIdx, end: DepositIdx) -> DbResult<()>;
+
+    /// Stores the deposit-info polling cursor.
+    fn put_deposit_info_cursor(&self, cursor: DepositIdx) -> DbResult<()>;
+
+    /// Stores the withdrawal-pairing cursor.
+    fn put_withdrawal_pairing_cursor(&self, cursor: WithdrawalPairingCursor) -> DbResult<()>;
+
+    /// Stores the withdrawal-status polling cursor.
+    fn put_withdrawal_status_cursor(&self, cursor: WithdrawalStatusCursor) -> DbResult<()>;
+
+    /// Stores the reimbursement-status polling cursor.
+    fn put_reimbursement_status_cursor(&self, cursor: ReimbursementStatusCursor) -> DbResult<()>;
 }

--- a/backend/crates/bridge/src/db/traits.rs
+++ b/backend/crates/bridge/src/db/traits.rs
@@ -82,10 +82,6 @@ pub(crate) trait BridgeStatusDb: Send + Sync {
     fn del_withdrawal_pairings_range(&self, start: DepositIdx, end: DepositIdx) -> DbResult<()>;
 
     /// Stores the deposit-info polling cursor.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired into state in follow-up commits")
-    )]
     fn put_deposit_info_cursor(&self, cursor: DepositIdx) -> DbResult<()>;
 
     /// Stores the withdrawal-pairing cursor.

--- a/backend/crates/bridge/src/db/traits.rs
+++ b/backend/crates/bridge/src/db/traits.rs
@@ -57,10 +57,6 @@ pub(crate) trait BridgeStatusDb: Send + Sync {
     fn put_withdrawal_info(&self, deposit_idx: DepositIdx, info: &WithdrawalInfo) -> DbResult<()>;
 
     /// Deletes one withdrawal status row.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired into state in follow-up commits")
-    )]
     fn del_withdrawal_info(&self, deposit_idx: DepositIdx) -> DbResult<bool>;
 
     /// Inserts or replaces withdrawal-to-deposit pairings.
@@ -79,9 +75,5 @@ pub(crate) trait BridgeStatusDb: Send + Sync {
     fn put_withdrawal_status_cursor(&self, cursor: WithdrawalStatusCursor) -> DbResult<()>;
 
     /// Stores the reimbursement-status polling cursor.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired into state in follow-up commits")
-    )]
     fn put_reimbursement_status_cursor(&self, cursor: ReimbursementStatusCursor) -> DbResult<()>;
 }

--- a/backend/crates/bridge/src/db/traits.rs
+++ b/backend/crates/bridge/src/db/traits.rs
@@ -49,38 +49,63 @@ pub(crate) trait WithdrawalIndexerDb: Send + Sync {
 }
 
 /// Storage contract for bridge status rows, pairings, and cursors.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "status DB trait is consumed when persistence is wired into state"
-    )
-)]
 pub(crate) trait BridgeStatusDb: Send + Sync {
     /// Loads all persisted status rows, pairings, and cursors.
     fn get_status_snapshot(&self) -> DbResult<DbBridgeStatusSnapshot>;
 
     /// Inserts or replaces one withdrawal status row.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired into state in follow-up commits")
+    )]
     fn put_withdrawal_info(&self, deposit_idx: DepositIdx, info: &WithdrawalInfo) -> DbResult<()>;
 
     /// Deletes one withdrawal status row.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired into state in follow-up commits")
+    )]
     fn del_withdrawal_info(&self, deposit_idx: DepositIdx) -> DbResult<bool>;
 
     /// Inserts or replaces withdrawal-to-deposit pairings.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired into state in follow-up commits")
+    )]
     fn put_withdrawal_pairings(&self, pairings: &[(DepositIdx, WithdrawalSeq)]) -> DbResult<()>;
 
     /// Deletes withdrawal-to-deposit pairing rows in `start..end`.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired into state in follow-up commits")
+    )]
     fn del_withdrawal_pairings_range(&self, start: DepositIdx, end: DepositIdx) -> DbResult<()>;
 
     /// Stores the deposit-info polling cursor.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired into state in follow-up commits")
+    )]
     fn put_deposit_info_cursor(&self, cursor: DepositIdx) -> DbResult<()>;
 
     /// Stores the withdrawal-pairing cursor.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired into state in follow-up commits")
+    )]
     fn put_withdrawal_pairing_cursor(&self, cursor: WithdrawalPairingCursor) -> DbResult<()>;
 
     /// Stores the withdrawal-status polling cursor.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired into state in follow-up commits")
+    )]
     fn put_withdrawal_status_cursor(&self, cursor: WithdrawalStatusCursor) -> DbResult<()>;
 
     /// Stores the reimbursement-status polling cursor.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired into state in follow-up commits")
+    )]
     fn put_reimbursement_status_cursor(&self, cursor: ReimbursementStatusCursor) -> DbResult<()>;
 }

--- a/backend/crates/bridge/src/db/traits.rs
+++ b/backend/crates/bridge/src/db/traits.rs
@@ -68,10 +68,6 @@ pub(crate) trait BridgeStatusDb: Send + Sync {
     fn del_withdrawal_info(&self, deposit_idx: DepositIdx) -> DbResult<bool>;
 
     /// Inserts or replaces withdrawal-to-deposit pairings.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired into state in follow-up commits")
-    )]
     fn put_withdrawal_pairings(&self, pairings: &[(DepositIdx, WithdrawalSeq)]) -> DbResult<()>;
 
     /// Deletes withdrawal-to-deposit pairing rows in `start..end`.
@@ -85,10 +81,6 @@ pub(crate) trait BridgeStatusDb: Send + Sync {
     fn put_deposit_info_cursor(&self, cursor: DepositIdx) -> DbResult<()>;
 
     /// Stores the withdrawal-pairing cursor.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired into state in follow-up commits")
-    )]
     fn put_withdrawal_pairing_cursor(&self, cursor: WithdrawalPairingCursor) -> DbResult<()>;
 
     /// Stores the withdrawal-status polling cursor.

--- a/backend/crates/bridge/src/db/types.rs
+++ b/backend/crates/bridge/src/db/types.rs
@@ -1,7 +1,37 @@
 //! Types shared by DB traits and implementations.
 
 use serde::{Deserialize, Serialize};
+use strata_bridge_primitives::types::DepositIdx;
 use strata_primitives::buf::Buf32;
+
+use crate::types::{
+    ReimbursementStatusCursor, WithdrawalInfo, WithdrawalPairingCursor, WithdrawalSeq,
+    WithdrawalStatusCursor,
+};
+
+/// Assembled snapshot of bridge-status cursors.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct StatusCursors {
+    pub(crate) deposit_info: DepositIdx,
+    pub(crate) withdrawal_pairing: WithdrawalPairingCursor,
+    pub(crate) withdrawal_status: WithdrawalStatusCursor,
+    pub(crate) reimbursement_status: ReimbursementStatusCursor,
+}
+
+/// Snapshot of all persisted bridge-status rows and cursors.
+#[derive(Debug, Clone)]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "status DB snapshot is consumed when persistence is wired into state"
+    )
+)]
+pub(crate) struct DbBridgeStatusSnapshot {
+    pub(crate) withdrawals: Vec<(DepositIdx, WithdrawalInfo)>,
+    pub(crate) withdrawal_pairings: Vec<(DepositIdx, WithdrawalSeq)>,
+    pub(crate) cursors: StatusCursors,
+}
 
 /// Indexer checkpoint. Tracks the highest block number that has been fully
 /// processed; the next scan resumes from `last_scanned_block + 1`.

--- a/backend/crates/bridge/src/db/types.rs
+++ b/backend/crates/bridge/src/db/types.rs
@@ -20,13 +20,6 @@ pub(crate) struct StatusCursors {
 
 /// Snapshot of all persisted bridge-status rows and cursors.
 #[derive(Debug, Clone)]
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "status DB snapshot is consumed when persistence is wired into state"
-    )
-)]
 pub(crate) struct DbBridgeStatusSnapshot {
     pub(crate) withdrawals: Vec<(DepositIdx, WithdrawalInfo)>,
     pub(crate) withdrawal_pairings: Vec<(DepositIdx, WithdrawalSeq)>,

--- a/backend/crates/bridge/src/lib.rs
+++ b/backend/crates/bridge/src/lib.rs
@@ -11,7 +11,7 @@ mod withdrawal_requests;
 mod withdrawal_status;
 
 pub use context::BridgeMonitoringContext;
-pub use db::WithdrawalIndexerDbSled;
+pub use db::{BridgeStatusDbSled, WithdrawalIndexerDbSled};
 pub use status::{bridge_monitoring_task, get_bridge_status};
 pub use types::BridgeStatus;
 pub use withdrawal_indexer::task::run_withdrawal_indexer;

--- a/backend/crates/bridge/src/state.rs
+++ b/backend/crates/bridge/src/state.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeSet;
 
 use strata_bridge_primitives::types::DepositIdx;
 use tokio::sync::RwLock;
+use tracing::warn;
 
 use super::{
     cache::BridgeStatusCache,
@@ -175,12 +176,13 @@ impl BridgeMonitoringState {
 
     pub(crate) async fn apply_withdrawal_updates(
         &self,
+        status_db: &impl BridgeStatusDb,
         updates: Vec<WithdrawalInfoUpdate>,
         max_confirmations: u64,
-    ) {
+    ) -> DbResult<()> {
         let mut cache_updates = Vec::new();
+        let mut withdrawal_infos_to_persist = Vec::new();
         let mut terminal_deposit_indices_to_purge = Vec::new();
-        let mut withdrawal_deposit_indices_to_purge = Vec::new();
 
         for update in updates {
             match update.info.status {
@@ -194,31 +196,50 @@ impl BridgeMonitoringState {
 
                     if confirmations >= max_confirmations {
                         terminal_deposit_indices_to_purge.push(update.deposit_idx);
-                        withdrawal_deposit_indices_to_purge.push(update.deposit_idx);
-                    } else {
-                        cache_updates.push((update.deposit_idx, update.info, Some(confirmations)));
                     }
+                    withdrawal_infos_to_persist.push((update.deposit_idx, update.info));
+                    cache_updates.push((update.deposit_idx, update.info, Some(confirmations)));
                 }
             }
         }
 
+        let current_cursor = {
+            let cache = self.cache.read().await;
+            cache.withdrawal_status_cursor()
+        };
+        let next_cursor =
+            next_withdrawal_status_cursor(current_cursor, &terminal_deposit_indices_to_purge);
+        for (deposit_idx, info) in &withdrawal_infos_to_persist {
+            status_db.put_withdrawal_info(*deposit_idx, info)?;
+        }
+        status_db.put_withdrawal_status_cursor(next_cursor)?;
+
+        let pairing_purge_frontier = next_cursor.next_deposit_idx;
+        let pairings_purged =
+            match status_db.del_withdrawal_pairings_range(0, pairing_purge_frontier) {
+                Ok(()) => true,
+                Err(e) => {
+                    warn!(error = %e, "failed to purge old withdrawal pairings");
+                    false
+                }
+            };
+
         let mut cache = self.cache.write().await;
-        let next_cursor = next_withdrawal_status_cursor(
-            cache.withdrawal_status_cursor(),
-            &terminal_deposit_indices_to_purge,
-        );
         cache.apply_withdrawal_updates(cache_updates);
-        cache.purge_withdrawals(withdrawal_deposit_indices_to_purge);
+        if pairings_purged {
+            cache.purge_withdrawal_pairings_range(0, pairing_purge_frontier);
+        }
         cache.set_withdrawal_status_cursor(next_cursor);
+        Ok(())
     }
 
     pub(crate) async fn select_reimbursement_status_candidates(&self) -> Vec<DepositIdx> {
         let cache = self.cache.read().await;
         let cursor = cache.reimbursement_status_cursor().next_deposit_idx;
         cache
-            .withdrawal_pairings_from(cursor)
+            .filter_withdrawals(|status| matches!(status, WithdrawalStatus::Complete))
             .into_iter()
-            .map(|(deposit_idx, _)| deposit_idx)
+            .filter_map(|(deposit_idx, _)| (deposit_idx >= cursor).then_some(deposit_idx))
             .collect()
     }
 
@@ -539,7 +560,7 @@ mod tests {
             .expect("put pairing cursor");
         status_db
             .put_withdrawal_status_cursor(WithdrawalStatusCursor {
-                next_deposit_idx: 2,
+                next_deposit_idx: 3,
             })
             .expect("put withdrawal cursor");
         status_db
@@ -566,10 +587,7 @@ mod tests {
         );
         assert_eq!(
             state.select_withdrawal_status_candidates().await,
-            vec![WithdrawalStatusCandidate {
-                deposit_idx: 2,
-                withdrawal_seq: 7,
-            }]
+            Vec::<WithdrawalStatusCandidate>::new()
         );
         assert_eq!(
             state.select_reimbursement_status_candidates().await,
@@ -713,6 +731,7 @@ mod tests {
 
         state
             .apply_withdrawal_updates(
+                &status_db,
                 vec![WithdrawalInfoUpdate {
                     deposit_idx: 0,
                     info: WithdrawalInfo {
@@ -724,8 +743,60 @@ mod tests {
                 }],
                 6,
             )
-            .await;
+            .await
+            .expect("persist withdrawal status");
 
+        assert_eq!(
+            state.select_withdrawal_status_candidates().await,
+            vec![WithdrawalStatusCandidate {
+                deposit_idx: 1,
+                withdrawal_seq: 1
+            }]
+        );
+        let snapshot = status_db
+            .get_status_snapshot()
+            .expect("load status snapshot");
+        assert_eq!(
+            snapshot.withdrawal_pairings,
+            vec![(1, 1)],
+            "confirmed withdrawal pairings below the cursor are purged"
+        );
+        assert_eq!(
+            snapshot.cursors.withdrawal_status,
+            WithdrawalStatusCursor {
+                next_deposit_idx: 1
+            }
+        );
+        assert_eq!(snapshot.withdrawals.len(), 1);
+        assert_eq!(snapshot.withdrawals[0].0, 0);
+    }
+
+    #[tokio::test]
+    async fn pairing_gc_retries_below_cursor() {
+        let status_db = BridgeStatusDbSled::open_temporary().expect("open status db");
+        status_db
+            .put_withdrawal_pairings(&[(0, 0), (1, 1)])
+            .expect("put withdrawal pairings");
+        status_db
+            .put_withdrawal_status_cursor(WithdrawalStatusCursor {
+                next_deposit_idx: 1,
+            })
+            .expect("put withdrawal status cursor");
+
+        let snapshot = status_db
+            .get_status_snapshot()
+            .expect("load status snapshot");
+        let state = BridgeMonitoringState::from_snapshot(snapshot);
+
+        state
+            .apply_withdrawal_updates(&status_db, Vec::new(), 6)
+            .await
+            .expect("persist withdrawal status");
+
+        let snapshot = status_db
+            .get_status_snapshot()
+            .expect("load status snapshot");
+        assert_eq!(snapshot.withdrawal_pairings, vec![(1, 1)]);
         assert_eq!(
             state.select_withdrawal_status_candidates().await,
             vec![WithdrawalStatusCandidate {
@@ -737,11 +808,13 @@ mod tests {
 
     #[tokio::test]
     async fn withdrawal_cache_allows_shared_request_tx_hash() {
+        let status_db = BridgeStatusDbSled::open_temporary().expect("open status db");
         let state = BridgeMonitoringState::default();
         let withdrawal_request_txid = Buf32([9; 32]);
 
         state
             .apply_withdrawal_updates(
+                &status_db,
                 vec![
                     WithdrawalInfoUpdate {
                         deposit_idx: 0,
@@ -764,7 +837,8 @@ mod tests {
                 ],
                 6,
             )
-            .await;
+            .await
+            .expect("persist withdrawal status");
 
         let status = state.bridge_status().await;
 
@@ -773,10 +847,18 @@ mod tests {
             .withdrawals
             .iter()
             .all(|info| info.withdrawal_request_txid == withdrawal_request_txid));
+        assert!(
+            status_db
+                .get_status_snapshot()
+                .expect("load status snapshot")
+                .withdrawals
+                .is_empty(),
+            "in-progress withdrawal rows are cache-only"
+        );
     }
 
     #[tokio::test]
-    async fn reimbursement_status_candidates_follow_cursor() {
+    async fn reimbursement_candidates_use_complete_withdrawals() {
         let status_db = BridgeStatusDbSled::open_temporary().expect("open status db");
         let state = BridgeMonitoringState::default();
         let requests = vec![DbWithdrawalRequestRow {
@@ -793,6 +875,37 @@ mod tests {
             .apply_withdrawal_pairings(&status_db, &[0], &requests)
             .await
             .expect("persist withdrawal pairings");
+        assert_eq!(
+            state.select_reimbursement_status_candidates().await,
+            Vec::<DepositIdx>::new()
+        );
+
+        state
+            .apply_withdrawal_updates(
+                &status_db,
+                vec![WithdrawalInfoUpdate {
+                    deposit_idx: 0,
+                    info: WithdrawalInfo {
+                        withdrawal_request_txid: requests[0].request.tx_hash,
+                        fulfillment_txid: Some(Txid::from_byte_array([3; 32])),
+                        status: WithdrawalStatus::Complete,
+                    },
+                    confirmations: Some(1),
+                }],
+                6,
+            )
+            .await
+            .expect("persist withdrawal status");
+        assert_eq!(
+            status_db
+                .get_status_snapshot()
+                .expect("load status snapshot")
+                .cursors
+                .withdrawal_status,
+            WithdrawalStatusCursor {
+                next_deposit_idx: 0
+            }
+        );
         assert_eq!(
             state.select_reimbursement_status_candidates().await,
             vec![0]
@@ -817,6 +930,45 @@ mod tests {
         assert_eq!(
             state.select_reimbursement_status_candidates().await,
             Vec::<DepositIdx>::new()
+        );
+    }
+
+    #[tokio::test]
+    async fn reimbursement_candidates_skip_incomplete_withdrawals() {
+        let status_db = BridgeStatusDbSled::open_temporary().expect("open status db");
+        let state = BridgeMonitoringState::default();
+
+        state
+            .apply_withdrawal_updates(
+                &status_db,
+                vec![
+                    WithdrawalInfoUpdate {
+                        deposit_idx: 0,
+                        info: WithdrawalInfo {
+                            withdrawal_request_txid: Buf32([10; 32]),
+                            fulfillment_txid: None,
+                            status: WithdrawalStatus::InProgress,
+                        },
+                        confirmations: None,
+                    },
+                    WithdrawalInfoUpdate {
+                        deposit_idx: 1,
+                        info: WithdrawalInfo {
+                            withdrawal_request_txid: Buf32([11; 32]),
+                            fulfillment_txid: Some(Txid::from_byte_array([12; 32])),
+                            status: WithdrawalStatus::Complete,
+                        },
+                        confirmations: Some(1),
+                    },
+                ],
+                6,
+            )
+            .await
+            .expect("persist withdrawal status");
+
+        assert_eq!(
+            state.select_reimbursement_status_candidates().await,
+            vec![1]
         );
     }
 }

--- a/backend/crates/bridge/src/state.rs
+++ b/backend/crates/bridge/src/state.rs
@@ -4,14 +4,12 @@ use strata_bridge_primitives::types::DepositIdx;
 use tokio::sync::RwLock;
 
 use super::{
-    cache::{
-        BridgeStatusCache, ReimbursementStatusCursor, WithdrawalPairingCursor,
-        WithdrawalStatusCursor,
-    },
+    cache::BridgeStatusCache,
     db::types::DbWithdrawalRequestRow,
     types::{
         BridgeStatus, DepositInfo, DepositStatus, OperatorStatus, ReimbursementInfo,
-        ReimbursementStatus, WithdrawalInfo, WithdrawalStatus,
+        ReimbursementStatus, ReimbursementStatusCursor, WithdrawalInfo, WithdrawalPairingCursor,
+        WithdrawalSeq, WithdrawalStatus, WithdrawalStatusCursor,
     },
 };
 
@@ -30,7 +28,7 @@ pub(crate) struct DepositInfoUpdate {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct WithdrawalStatusCandidate {
     pub(crate) deposit_idx: DepositIdx,
-    pub(crate) withdrawal_seq: u64,
+    pub(crate) withdrawal_seq: WithdrawalSeq,
 }
 
 /// Withdrawal status update collected during one monitoring tick.
@@ -115,7 +113,7 @@ impl BridgeMonitoringState {
         &self,
         deposit_indices: &[DepositIdx],
         withdrawal_requests: &[DbWithdrawalRequestRow],
-    ) -> Vec<(DepositIdx, u64)> {
+    ) -> Vec<(DepositIdx, WithdrawalSeq)> {
         let withdrawal_seqs = withdrawal_requests
             .iter()
             .map(|row| row.seq)
@@ -331,8 +329,8 @@ fn next_reimbursement_status_cursor(
 fn plan_withdrawal_pairings(
     cursor: WithdrawalPairingCursor,
     discovered_deposit_indices: &[DepositIdx],
-    indexed_withdrawal_seqs: &[u64],
-) -> (Vec<(DepositIdx, u64)>, WithdrawalPairingCursor) {
+    indexed_withdrawal_seqs: &[WithdrawalSeq],
+) -> (Vec<(DepositIdx, WithdrawalSeq)>, WithdrawalPairingCursor) {
     let discovered_deposit_indices = discovered_deposit_indices
         .iter()
         .copied()

--- a/backend/crates/bridge/src/state.rs
+++ b/backend/crates/bridge/src/state.rs
@@ -235,19 +235,29 @@ impl BridgeMonitoringState {
 
     pub(crate) async fn select_reimbursement_status_candidates(&self) -> Vec<DepositIdx> {
         let cache = self.cache.read().await;
-        let cursor = cache.reimbursement_status_cursor().next_deposit_idx;
-        cache
-            .filter_withdrawals(|status| matches!(status, WithdrawalStatus::Complete))
-            .into_iter()
-            .filter_map(|(deposit_idx, _)| (deposit_idx >= cursor).then_some(deposit_idx))
-            .collect()
+        let reimbursement_cursor = cache.reimbursement_status_cursor().next_deposit_idx;
+        let withdrawal_cursor = cache.withdrawal_status_cursor().next_deposit_idx;
+        let mut candidates = (reimbursement_cursor..withdrawal_cursor).collect::<BTreeSet<_>>();
+
+        candidates.extend(
+            cache
+                .filter_withdrawals(|deposit_idx, info| {
+                    deposit_idx >= reimbursement_cursor
+                        && matches!(info.status, WithdrawalStatus::Complete)
+                })
+                .into_iter()
+                .map(|(deposit_idx, _)| deposit_idx),
+        );
+
+        candidates.into_iter().collect()
     }
 
     pub(crate) async fn apply_reimbursement_updates(
         &self,
+        status_db: &impl BridgeStatusDb,
         updates: Vec<ReimbursementInfoUpdate>,
         max_confirmations: u64,
-    ) {
+    ) -> DbResult<()> {
         let mut cache_updates = Vec::new();
         let mut terminal_deposit_indices_to_purge = Vec::new();
 
@@ -273,14 +283,41 @@ impl BridgeMonitoringState {
             }
         }
 
+        let (next_cursor, withdrawal_deposit_indices_to_purge) = {
+            let cache = self.cache.read().await;
+            let current_cursor = cache.reimbursement_status_cursor();
+            let next_cursor = next_reimbursement_status_cursor(
+                current_cursor,
+                &terminal_deposit_indices_to_purge,
+            );
+            (
+                next_cursor,
+                cache
+                    .filter_withdrawals(|deposit_idx, _| deposit_idx < next_cursor.next_deposit_idx)
+                    .into_iter()
+                    .map(|(deposit_idx, _)| deposit_idx)
+                    .collect::<Vec<_>>(),
+            )
+        };
+
+        status_db.put_reimbursement_status_cursor(next_cursor)?;
+
+        let mut purged_withdrawal_deposit_indices = Vec::new();
+        for deposit_idx in withdrawal_deposit_indices_to_purge {
+            match status_db.del_withdrawal_info(deposit_idx) {
+                Ok(_) => purged_withdrawal_deposit_indices.push(deposit_idx),
+                Err(e) => {
+                    warn!(deposit_idx, error = %e, "failed to purge old withdrawal row");
+                }
+            }
+        }
+
         let mut cache = self.cache.write().await;
-        let next_cursor = next_reimbursement_status_cursor(
-            cache.reimbursement_status_cursor(),
-            &terminal_deposit_indices_to_purge,
-        );
         cache.apply_reimbursement_updates(cache_updates);
         cache.purge_reimbursements(terminal_deposit_indices_to_purge);
+        cache.purge_withdrawals(purged_withdrawal_deposit_indices);
         cache.set_reimbursement_status_cursor(next_cursor);
+        Ok(())
     }
 
     pub(crate) async fn bridge_status(&self) -> BridgeStatus {
@@ -294,7 +331,7 @@ impl BridgeMonitoringState {
                 .map(|(_, info)| info)
                 .collect(),
             withdrawals: cache
-                .filter_withdrawals(|_| true)
+                .filter_withdrawals(|_, _| true)
                 .into_iter()
                 .map(|(_, info)| info)
                 .collect(),
@@ -913,6 +950,33 @@ mod tests {
 
         state
             .apply_reimbursement_updates(
+                &status_db,
+                vec![ReimbursementInfoUpdate {
+                    deposit_idx: 0,
+                    info: ReimbursementInfo {
+                        claim_txid: Txid::from_byte_array([4; 32]),
+                        challenge_step: crate::types::ChallengeStep::Claimed,
+                        payout_txid: None,
+                        status: ReimbursementStatus::InProgress,
+                    },
+                    confirmations: None,
+                }],
+                6,
+            )
+            .await
+            .expect("persist active reimbursement status");
+        let snapshot = status_db
+            .get_status_snapshot()
+            .expect("load status snapshot");
+        assert_eq!(
+            snapshot.cursors.reimbursement_status,
+            ReimbursementStatusCursor::default()
+        );
+        assert_eq!(snapshot.withdrawals.len(), 1);
+
+        state
+            .apply_reimbursement_updates(
+                &status_db,
                 vec![ReimbursementInfoUpdate {
                     deposit_idx: 0,
                     info: ReimbursementInfo {
@@ -925,12 +989,24 @@ mod tests {
                 }],
                 6,
             )
-            .await;
+            .await
+            .expect("persist reimbursement status");
 
         assert_eq!(
             state.select_reimbursement_status_candidates().await,
             Vec::<DepositIdx>::new()
         );
+        let snapshot = status_db
+            .get_status_snapshot()
+            .expect("load status snapshot");
+        assert_eq!(
+            snapshot.cursors.reimbursement_status,
+            ReimbursementStatusCursor {
+                next_deposit_idx: 1
+            }
+        );
+        assert!(snapshot.withdrawals.is_empty());
+        assert!(state.bridge_status().await.withdrawals.is_empty());
     }
 
     #[tokio::test]
@@ -969,6 +1045,31 @@ mod tests {
         assert_eq!(
             state.select_reimbursement_status_candidates().await,
             vec![1]
+        );
+    }
+
+    #[tokio::test]
+    async fn reimbursement_candidates_include_withdrawal_cursor_lag() {
+        let status_db = BridgeStatusDbSled::open_temporary().expect("open status db");
+        status_db
+            .put_withdrawal_status_cursor(WithdrawalStatusCursor {
+                next_deposit_idx: 3,
+            })
+            .expect("put withdrawal status cursor");
+        status_db
+            .put_reimbursement_status_cursor(ReimbursementStatusCursor {
+                next_deposit_idx: 1,
+            })
+            .expect("put reimbursement status cursor");
+
+        let snapshot = status_db
+            .get_status_snapshot()
+            .expect("load status snapshot");
+        let state = BridgeMonitoringState::from_snapshot(snapshot);
+
+        assert_eq!(
+            state.select_reimbursement_status_candidates().await,
+            vec![1, 2]
         );
     }
 }

--- a/backend/crates/bridge/src/state.rs
+++ b/backend/crates/bridge/src/state.rs
@@ -78,7 +78,7 @@ impl BridgeMonitoringState {
         for update in updates {
             match update.info.status {
                 DepositStatus::InProgress => {
-                    cache_updates.push((update.deposit_idx, update.info, 0));
+                    cache_updates.push((update.deposit_idx, update.info, None));
                 }
                 DepositStatus::Failed | DepositStatus::Complete => {
                     let Some(confirmations) = update.confirmations else {
@@ -88,7 +88,7 @@ impl BridgeMonitoringState {
                     if confirmations >= max_confirmations {
                         terminal_deposit_indices_to_purge.push(update.deposit_idx);
                     } else {
-                        cache_updates.push((update.deposit_idx, update.info, confirmations));
+                        cache_updates.push((update.deposit_idx, update.info, Some(confirmations)));
                     }
                 }
             }
@@ -161,7 +161,7 @@ impl BridgeMonitoringState {
         for update in updates {
             match update.info.status {
                 WithdrawalStatus::InProgress => {
-                    cache_updates.push((update.deposit_idx, update.info, 0));
+                    cache_updates.push((update.deposit_idx, update.info, None));
                 }
                 WithdrawalStatus::Complete => {
                     let Some(confirmations) = update.confirmations else {
@@ -172,7 +172,7 @@ impl BridgeMonitoringState {
                         terminal_deposit_indices_to_purge.push(update.deposit_idx);
                         withdrawal_deposit_indices_to_purge.push(update.deposit_idx);
                     } else {
-                        cache_updates.push((update.deposit_idx, update.info, confirmations));
+                        cache_updates.push((update.deposit_idx, update.info, Some(confirmations)));
                     }
                 }
             }
@@ -210,7 +210,7 @@ impl BridgeMonitoringState {
             match update.info.status {
                 ReimbursementStatus::NotStarted => continue,
                 ReimbursementStatus::InProgress => {
-                    cache_updates.push((update.deposit_idx, update.info, 0));
+                    cache_updates.push((update.deposit_idx, update.info, None));
                 }
                 ReimbursementStatus::Slashed
                 | ReimbursementStatus::Aborted
@@ -222,7 +222,7 @@ impl BridgeMonitoringState {
                     if confirmations >= max_confirmations {
                         terminal_deposit_indices_to_purge.push(update.deposit_idx);
                     } else {
-                        cache_updates.push((update.deposit_idx, update.info, confirmations));
+                        cache_updates.push((update.deposit_idx, update.info, Some(confirmations)));
                     }
                 }
             }

--- a/backend/crates/bridge/src/state.rs
+++ b/backend/crates/bridge/src/state.rs
@@ -5,7 +5,11 @@ use tokio::sync::RwLock;
 
 use super::{
     cache::BridgeStatusCache,
-    db::types::{DbBridgeStatusSnapshot, DbWithdrawalRequestRow},
+    db::{
+        error::DbResult,
+        traits::BridgeStatusDb,
+        types::{DbBridgeStatusSnapshot, DbWithdrawalRequestRow},
+    },
     types::{
         BridgeStatus, DepositInfo, DepositStatus, OperatorStatus, ReimbursementInfo,
         ReimbursementStatus, ReimbursementStatusCursor, WithdrawalInfo, WithdrawalPairingCursor,
@@ -75,9 +79,10 @@ impl BridgeMonitoringState {
 
     pub(crate) async fn apply_deposit_info_updates(
         &self,
+        status_db: &impl BridgeStatusDb,
         updates: Vec<DepositInfoUpdate>,
         max_confirmations: u64,
-    ) {
+    ) -> DbResult<()> {
         let mut cache_updates = Vec::new();
         let mut terminal_deposit_indices_to_purge = Vec::new();
 
@@ -100,14 +105,19 @@ impl BridgeMonitoringState {
             }
         }
 
+        let current_cursor = {
+            let cache = self.cache.read().await;
+            cache.deposit_info_cursor()
+        };
+        let next_cursor =
+            next_deposit_info_cursor(current_cursor, &terminal_deposit_indices_to_purge);
+        status_db.put_deposit_info_cursor(next_cursor)?;
+
         let mut cache = self.cache.write().await;
-        let next_cursor = next_deposit_info_cursor(
-            cache.deposit_info_cursor(),
-            &terminal_deposit_indices_to_purge,
-        );
         cache.apply_deposit_updates(cache_updates);
         cache.purge_deposits(terminal_deposit_indices_to_purge);
         cache.set_deposit_info_cursor(next_cursor);
+        Ok(())
     }
 
     pub(crate) async fn withdrawal_pairing_cursor(&self) -> WithdrawalPairingCursor {
@@ -562,6 +572,61 @@ mod tests {
         assert!(status.deposits.is_empty());
         assert_eq!(status.withdrawals.len(), 1);
         assert!(status.reimbursements.is_empty());
+    }
+
+    #[tokio::test]
+    async fn deposit_updates_persist_cursor_only() {
+        let status_db = BridgeStatusDbSled::open_temporary().expect("open status db");
+        let state = BridgeMonitoringState::default();
+        let deposit_request_txid = Txid::from_byte_array([6; 32]);
+        let deposit_txid = Txid::from_byte_array([7; 32]);
+
+        state
+            .apply_deposit_info_updates(
+                &status_db,
+                vec![DepositInfoUpdate {
+                    deposit_idx: 0,
+                    info: DepositInfo {
+                        deposit_request_txid,
+                        deposit_txid: None,
+                        status: DepositStatus::InProgress,
+                    },
+                    confirmations: None,
+                }],
+                6,
+            )
+            .await
+            .expect("persist deposit cursor");
+
+        let snapshot = status_db
+            .get_status_snapshot()
+            .expect("load status snapshot");
+        assert_eq!(snapshot.cursors.deposit_info, 0);
+        assert!(snapshot.withdrawals.is_empty());
+
+        state
+            .apply_deposit_info_updates(
+                &status_db,
+                vec![DepositInfoUpdate {
+                    deposit_idx: 0,
+                    info: DepositInfo {
+                        deposit_request_txid,
+                        deposit_txid: Some(deposit_txid),
+                        status: DepositStatus::Complete,
+                    },
+                    confirmations: Some(6),
+                }],
+                6,
+            )
+            .await
+            .expect("persist deposit cursor");
+
+        let snapshot = status_db
+            .get_status_snapshot()
+            .expect("load status snapshot");
+        assert_eq!(snapshot.cursors.deposit_info, 1);
+        assert!(snapshot.withdrawals.is_empty());
+        assert_eq!(state.select_deposit_info_candidates(&[0, 1]).await, vec![1]);
     }
 
     #[tokio::test]

--- a/backend/crates/bridge/src/state.rs
+++ b/backend/crates/bridge/src/state.rs
@@ -241,7 +241,7 @@ impl BridgeMonitoringState {
 
         candidates.extend(
             cache
-                .filter_withdrawals(|deposit_idx, info| {
+                .filter_withdrawals(|deposit_idx, info, _| {
                     deposit_idx >= reimbursement_cursor
                         && matches!(info.status, WithdrawalStatus::Complete)
                 })
@@ -293,7 +293,9 @@ impl BridgeMonitoringState {
             (
                 next_cursor,
                 cache
-                    .filter_withdrawals(|deposit_idx, _| deposit_idx < next_cursor.next_deposit_idx)
+                    .filter_withdrawals(|deposit_idx, _, _| {
+                        deposit_idx < next_cursor.next_deposit_idx
+                    })
                     .into_iter()
                     .map(|(deposit_idx, _)| deposit_idx)
                     .collect::<Vec<_>>(),
@@ -320,23 +322,42 @@ impl BridgeMonitoringState {
         Ok(())
     }
 
-    pub(crate) async fn bridge_status(&self) -> BridgeStatus {
+    pub(crate) async fn bridge_status(&self, max_confirmations: u64) -> BridgeStatus {
         let cache = self.cache.read().await;
 
         BridgeStatus {
             operators: cache.get_operators(),
             deposits: cache
-                .filter_deposits(|_| true)
+                // Omit terminal rows whose confirmations reached `max_confirmations`.
+                .filter_deposits(|_, info, confirmations| {
+                    !matches!(info.status, DepositStatus::Complete | DepositStatus::Failed)
+                        || confirmations
+                            .is_none_or(|confirmations| confirmations < max_confirmations)
+                })
                 .into_iter()
                 .map(|(_, info)| info)
                 .collect(),
             withdrawals: cache
-                .filter_withdrawals(|_, _| true)
+                // Complete withdrawals may be retained as reimbursement
+                // handoff state; omit them from this response at `max_confirmations`.
+                .filter_withdrawals(|_, info, confirmations| {
+                    !matches!(info.status, WithdrawalStatus::Complete)
+                        || confirmations
+                            .is_none_or(|confirmations| confirmations < max_confirmations)
+                })
                 .into_iter()
                 .map(|(_, info)| info)
                 .collect(),
             reimbursements: cache
-                .filter_reimbursements(|_| true)
+                // Omit terminal rows whose confirmations reached `max_confirmations`.
+                .filter_reimbursements(|_, info, confirmations| {
+                    !matches!(
+                        info.status,
+                        ReimbursementStatus::Complete
+                            | ReimbursementStatus::Slashed
+                            | ReimbursementStatus::Aborted
+                    ) || confirmations.is_none_or(|confirmations| confirmations < max_confirmations)
+                })
                 .into_iter()
                 .map(|(_, info)| info)
                 .collect(),
@@ -631,7 +652,7 @@ mod tests {
             vec![2]
         );
 
-        let status = state.bridge_status().await;
+        let status = state.bridge_status(6).await;
         assert!(status.deposits.is_empty());
         assert_eq!(status.withdrawals.len(), 1);
         assert!(status.reimbursements.is_empty());
@@ -877,7 +898,7 @@ mod tests {
             .await
             .expect("persist withdrawal status");
 
-        let status = state.bridge_status().await;
+        let status = state.bridge_status(6).await;
 
         assert_eq!(status.withdrawals.len(), 2);
         assert!(status
@@ -947,6 +968,29 @@ mod tests {
             state.select_reimbursement_status_candidates().await,
             vec![0]
         );
+        assert_eq!(state.bridge_status(6).await.withdrawals.len(), 1);
+
+        state
+            .apply_withdrawal_updates(
+                &status_db,
+                vec![WithdrawalInfoUpdate {
+                    deposit_idx: 0,
+                    info: WithdrawalInfo {
+                        withdrawal_request_txid: requests[0].request.tx_hash,
+                        fulfillment_txid: Some(Txid::from_byte_array([3; 32])),
+                        status: WithdrawalStatus::Complete,
+                    },
+                    confirmations: Some(6),
+                }],
+                6,
+            )
+            .await
+            .expect("persist confirmed withdrawal status");
+        assert_eq!(
+            state.select_reimbursement_status_candidates().await,
+            vec![0]
+        );
+        assert!(state.bridge_status(6).await.withdrawals.is_empty());
 
         state
             .apply_reimbursement_updates(
@@ -1006,7 +1050,7 @@ mod tests {
             }
         );
         assert!(snapshot.withdrawals.is_empty());
-        assert!(state.bridge_status().await.withdrawals.is_empty());
+        assert!(state.bridge_status(6).await.withdrawals.is_empty());
     }
 
     #[tokio::test]

--- a/backend/crates/bridge/src/state.rs
+++ b/backend/crates/bridge/src/state.rs
@@ -5,7 +5,7 @@ use tokio::sync::RwLock;
 
 use super::{
     cache::BridgeStatusCache,
-    db::types::DbWithdrawalRequestRow,
+    db::types::{DbBridgeStatusSnapshot, DbWithdrawalRequestRow},
     types::{
         BridgeStatus, DepositInfo, DepositStatus, OperatorStatus, ReimbursementInfo,
         ReimbursementStatus, ReimbursementStatusCursor, WithdrawalInfo, WithdrawalPairingCursor,
@@ -54,6 +54,12 @@ pub(crate) struct BridgeMonitoringState {
 }
 
 impl BridgeMonitoringState {
+    pub(crate) fn from_snapshot(snapshot: DbBridgeStatusSnapshot) -> Self {
+        Self {
+            cache: RwLock::new(cache_from_status_snapshot(snapshot)),
+        }
+    }
+
     pub(crate) async fn select_deposit_info_candidates(
         &self,
         deposit_indices: &[DepositIdx],
@@ -262,6 +268,27 @@ impl BridgeMonitoringState {
     }
 }
 
+fn cache_from_status_snapshot(snapshot: DbBridgeStatusSnapshot) -> BridgeStatusCache {
+    let mut cache = BridgeStatusCache::default();
+
+    cache.apply_withdrawal_updates(
+        snapshot
+            .withdrawals
+            .into_iter()
+            .map(|(deposit_idx, info)| (deposit_idx, info, None))
+            .collect(),
+    );
+    cache.update_withdrawal_pairings(
+        &snapshot.withdrawal_pairings,
+        snapshot.cursors.withdrawal_pairing,
+    );
+    cache.set_deposit_info_cursor(snapshot.cursors.deposit_info);
+    cache.set_withdrawal_status_cursor(snapshot.cursors.withdrawal_status);
+    cache.set_reimbursement_status_cursor(snapshot.cursors.reimbursement_status);
+
+    cache
+}
+
 fn next_deposit_info_cursor(
     current_cursor: DepositIdx,
     terminal_deposit_indices_to_purge: &[DepositIdx],
@@ -371,6 +398,8 @@ mod tests {
     use bitcoin::{hashes::Hash, Txid};
     use strata_primitives::buf::Buf32;
 
+    use crate::db::{traits::BridgeStatusDb, BridgeStatusDbSled};
+
     #[test]
     fn deposit_info_cursor_advances_over_contiguous_purged_deposits() {
         assert_eq!(next_deposit_info_cursor(0, &[0, 1, 3]), 2);
@@ -464,6 +493,75 @@ mod tests {
 
         assert!(pairings.is_empty());
         assert_eq!(next_cursor, cursor);
+    }
+
+    #[tokio::test]
+    async fn hydrates_persisted_status_snapshot() {
+        let status_db = BridgeStatusDbSled::open_temporary().expect("open status db");
+        let withdrawal_info = WithdrawalInfo {
+            withdrawal_request_txid: Buf32([2; 32]),
+            fulfillment_txid: Some(Txid::from_byte_array([4; 32])),
+            status: WithdrawalStatus::Complete,
+        };
+
+        status_db
+            .put_withdrawal_info(2, &withdrawal_info)
+            .expect("put withdrawal info");
+        status_db
+            .put_withdrawal_pairings(&[(2, 7)])
+            .expect("put withdrawal pairing");
+        status_db
+            .put_deposit_info_cursor(2)
+            .expect("put deposit cursor");
+        status_db
+            .put_withdrawal_pairing_cursor(WithdrawalPairingCursor {
+                next_deposit_idx: 3,
+                next_withdrawal_seq: 8,
+            })
+            .expect("put pairing cursor");
+        status_db
+            .put_withdrawal_status_cursor(WithdrawalStatusCursor {
+                next_deposit_idx: 2,
+            })
+            .expect("put withdrawal cursor");
+        status_db
+            .put_reimbursement_status_cursor(ReimbursementStatusCursor {
+                next_deposit_idx: 2,
+            })
+            .expect("put reimbursement cursor");
+
+        let snapshot = status_db
+            .get_status_snapshot()
+            .expect("load status snapshot");
+        let state = BridgeMonitoringState::from_snapshot(snapshot);
+
+        assert_eq!(
+            state.withdrawal_pairing_cursor().await,
+            WithdrawalPairingCursor {
+                next_deposit_idx: 3,
+                next_withdrawal_seq: 8,
+            }
+        );
+        assert_eq!(
+            state.select_deposit_info_candidates(&[0, 1, 2]).await,
+            vec![2]
+        );
+        assert_eq!(
+            state.select_withdrawal_status_candidates().await,
+            vec![WithdrawalStatusCandidate {
+                deposit_idx: 2,
+                withdrawal_seq: 7,
+            }]
+        );
+        assert_eq!(
+            state.select_reimbursement_status_candidates().await,
+            vec![2]
+        );
+
+        let status = state.bridge_status().await;
+        assert!(status.deposits.is_empty());
+        assert_eq!(status.withdrawals.len(), 1);
+        assert!(status.reimbursements.is_empty());
     }
 
     #[tokio::test]

--- a/backend/crates/bridge/src/state.rs
+++ b/backend/crates/bridge/src/state.rs
@@ -127,22 +127,30 @@ impl BridgeMonitoringState {
 
     pub(crate) async fn apply_withdrawal_pairings(
         &self,
+        status_db: &impl BridgeStatusDb,
         deposit_indices: &[DepositIdx],
         withdrawal_requests: &[DbWithdrawalRequestRow],
-    ) -> Vec<(DepositIdx, WithdrawalSeq)> {
+    ) -> DbResult<Vec<(DepositIdx, WithdrawalSeq)>> {
         let withdrawal_seqs = withdrawal_requests
             .iter()
             .map(|row| row.seq)
             .collect::<Vec<_>>();
-        let mut cache = self.cache.write().await;
-        let (pairings, next_cursor) = plan_withdrawal_pairings(
-            cache.withdrawal_pairing_cursor(),
-            deposit_indices,
-            &withdrawal_seqs,
-        );
+        let current_cursor = {
+            let cache = self.cache.read().await;
+            cache.withdrawal_pairing_cursor()
+        };
+        let (pairings, next_cursor) =
+            plan_withdrawal_pairings(current_cursor, deposit_indices, &withdrawal_seqs);
+        if pairings.is_empty() {
+            return Ok(pairings);
+        }
 
+        status_db.put_withdrawal_pairings(&pairings)?;
+        status_db.put_withdrawal_pairing_cursor(next_cursor)?;
+
+        let mut cache = self.cache.write().await;
         cache.update_withdrawal_pairings(&pairings, next_cursor);
-        pairings
+        Ok(pairings)
     }
 
     pub(crate) async fn select_withdrawal_status_candidates(
@@ -630,7 +638,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn withdrawal_pairings_apply_atomically_with_cursor() {
+    async fn withdrawal_pairings_persist_rows_and_cursor() {
+        let status_db = BridgeStatusDbSled::open_temporary().expect("open status db");
         let state = BridgeMonitoringState::default();
         let requests = vec![
             DbWithdrawalRequestRow {
@@ -643,7 +652,10 @@ mod tests {
             },
         ];
 
-        let pairings = state.apply_withdrawal_pairings(&[0, 1], &requests).await;
+        let pairings = state
+            .apply_withdrawal_pairings(&status_db, &[0, 1], &requests)
+            .await
+            .expect("persist withdrawal pairings");
 
         assert_eq!(pairings, vec![(0, 0), (1, 1)]);
         assert_eq!(
@@ -653,10 +665,22 @@ mod tests {
                 next_withdrawal_seq: 2
             }
         );
+        let snapshot = status_db
+            .get_status_snapshot()
+            .expect("load status snapshot");
+        assert_eq!(snapshot.withdrawal_pairings, vec![(0, 0), (1, 1)]);
+        assert_eq!(
+            snapshot.cursors.withdrawal_pairing,
+            WithdrawalPairingCursor {
+                next_deposit_idx: 2,
+                next_withdrawal_seq: 2
+            }
+        );
     }
 
     #[tokio::test]
     async fn withdrawal_status_candidates_follow_cursor() {
+        let status_db = BridgeStatusDbSled::open_temporary().expect("open status db");
         let state = BridgeMonitoringState::default();
         let requests = vec![
             DbWithdrawalRequestRow {
@@ -669,7 +693,10 @@ mod tests {
             },
         ];
 
-        state.apply_withdrawal_pairings(&[0, 1], &requests).await;
+        state
+            .apply_withdrawal_pairings(&status_db, &[0, 1], &requests)
+            .await
+            .expect("persist withdrawal pairings");
         assert_eq!(
             state.select_withdrawal_status_candidates().await,
             vec![
@@ -750,6 +777,7 @@ mod tests {
 
     #[tokio::test]
     async fn reimbursement_status_candidates_follow_cursor() {
+        let status_db = BridgeStatusDbSled::open_temporary().expect("open status db");
         let state = BridgeMonitoringState::default();
         let requests = vec![DbWithdrawalRequestRow {
             seq: 0,
@@ -761,7 +789,10 @@ mod tests {
             Vec::<DepositIdx>::new()
         );
 
-        state.apply_withdrawal_pairings(&[0], &requests).await;
+        state
+            .apply_withdrawal_pairings(&status_db, &[0], &requests)
+            .await
+            .expect("persist withdrawal pairings");
         assert_eq!(
             state.select_reimbursement_status_candidates().await,
             vec![0]

--- a/backend/crates/bridge/src/status.rs
+++ b/backend/crates/bridge/src/status.rs
@@ -96,10 +96,17 @@ pub async fn bridge_monitoring_task(
             new_deposit_indices_count,
             context.config().withdrawal_pairing_batch_size(),
         );
-        let new_pairings = context
+        let new_pairings = match context
             .state()
-            .apply_withdrawal_pairings(&deposit_indices, &withdrawal_requests)
-            .await;
+            .apply_withdrawal_pairings(context.status_db(), &deposit_indices, &withdrawal_requests)
+            .await
+        {
+            Ok(pairings) => pairings,
+            Err(e) => {
+                warn!(error = %e, "failed to persist withdrawal pairings");
+                Vec::new()
+            }
+        };
         if !new_pairings.is_empty() {
             info!(
                 pairing_count = new_pairings.len(),

--- a/backend/crates/bridge/src/status.rs
+++ b/backend/crates/bridge/src/status.rs
@@ -124,10 +124,17 @@ pub async fn bridge_monitoring_task(
             context.config().withdrawal_pairing_batch_size(),
         )
         .await;
-        context
+        if let Err(e) = context
             .state()
-            .apply_withdrawal_updates(withdrawal_updates, context.config().max_tx_confirmations())
-            .await;
+            .apply_withdrawal_updates(
+                context.status_db(),
+                withdrawal_updates,
+                context.config().max_tx_confirmations(),
+            )
+            .await
+        {
+            warn!(error = %e, "failed to persist withdrawal status updates");
+        }
 
         let reimbursement_candidates = context
             .state()

--- a/backend/crates/bridge/src/status.rs
+++ b/backend/crates/bridge/src/status.rs
@@ -75,13 +75,17 @@ pub async fn bridge_monitoring_task(
         let deposit_infos = get_deposits(context.bridge_rpc(), &deposit_candidates).await;
         let deposit_info_updates =
             get_deposit_info_updates(context.esplora(), chain_tip_height, deposit_infos).await;
-        context
+        if let Err(e) = context
             .state()
             .apply_deposit_info_updates(
+                context.status_db(),
                 deposit_info_updates,
                 context.config().max_tx_confirmations(),
             )
-            .await;
+            .await
+        {
+            warn!(error = %e, "failed to persist deposit status updates");
+        }
 
         let pairing_cursor = context.state().withdrawal_pairing_cursor().await;
         let new_deposit_indices_count =

--- a/backend/crates/bridge/src/status.rs
+++ b/backend/crates/bridge/src/status.rs
@@ -147,13 +147,17 @@ pub async fn bridge_monitoring_task(
             &reimbursement_candidates,
         )
         .await;
-        context
+        if let Err(e) = context
             .state()
             .apply_reimbursement_updates(
+                context.status_db(),
                 reimbursement_updates,
                 context.config().max_tx_confirmations(),
             )
-            .await;
+            .await
+        {
+            warn!(error = %e, "failed to persist reimbursement status updates");
+        }
 
         context.mark_status_available();
     }

--- a/backend/crates/bridge/src/types.rs
+++ b/backend/crates/bridge/src/types.rs
@@ -1,10 +1,14 @@
 use bitcoin::{secp256k1::PublicKey, Txid};
 use serde::{Deserialize, Serialize};
+use strata_bridge_primitives::types::DepositIdx;
 use strata_bridge_rpc::types::{
     RpcClaimPhase, RpcDepositInfo, RpcDepositStatus, RpcOperatorStatus, RpcReimbursementStatus,
     RpcWithdrawalStatus,
 };
 use strata_primitives::buf::Buf32;
+
+/// FIFO withdrawal-request sequence number.
+pub(crate) type WithdrawalSeq = u64;
 
 /// Bridge operator status
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -26,6 +30,25 @@ impl OperatorStatus {
             status,
         }
     }
+}
+
+/// In-memory cursor for withdrawal-to-deposit pairing progress.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct WithdrawalPairingCursor {
+    pub(crate) next_deposit_idx: DepositIdx,
+    pub(crate) next_withdrawal_seq: WithdrawalSeq,
+}
+
+/// In-memory cursor for bridge withdrawal status polling progress.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct WithdrawalStatusCursor {
+    pub(crate) next_deposit_idx: DepositIdx,
+}
+
+/// In-memory cursor for bridge reimbursement status polling progress.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ReimbursementStatusCursor {
+    pub(crate) next_deposit_idx: DepositIdx,
 }
 
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]


### PR DESCRIPTION
## Description

Adds durable persistence for bridge status monitoring progress.

The dashboard now persists withdrawal handoff rows, withdrawal pairings, and polling cursors in a sled-backed status DB. On restart, the bridge monitor hydrates its in-memory cache from the DB and resumes polling from persisted cursors instead of starting from scratch.

### Key Changes
- Add `BridgeStatusDbSled` for persisted complete-withdrawal handoff rows, withdrawal pairings, and status cursors.
- Hydrate `BridgeMonitoringState` from the status DB at startup.
- Persist deposit, withdrawal-pairing, withdrawal-status, and reimbursement cursors before mutating the in-memory cache.
- Persist withdrawal pairings for withdrawal-status polling.
- Persist complete withdrawal rows as durable handoff state for reimbursement polling.
- Keep deposit, in-progress withdrawal, and reimbursement status rows cache-only.
- Keep reimbursement polling based on retained complete withdrawal rows, not withdrawal pairings.
- Omit terminal rows from `bridge_status` once their confirmations reach `max_confirmations`.
- Purge old pairings after withdrawal status is confirmed past them.
- Purge old withdrawal handoff rows after reimbursement status advances past them.
- Keep DB failures domain-local: log and retry on later ticks instead of stopping the whole monitoring loop.

[STR-3295](https://alpenlabs.atlassian.net/browse/STR-3295)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
- Added status DB unit coverage for empty snapshots, withdrawal-row/cursor round trips, pairing range deletes, and sled reopen persistence.
- Added hydration coverage for rebuilding `BridgeMonitoringState` from persisted complete withdrawal rows, pairings, and cursors.
- Added cursor persistence coverage for deposit, withdrawal, and reimbursement polling progress.
- Added withdrawal pairing persistence coverage for rows plus pairing cursor.
- Added withdrawal status persistence coverage, including shared WRT tx hash rows keyed by `DepositIdx`, complete-row handoff persistence, and pairing GC.
- Added reimbursement cursor persistence coverage, including GC of completed withdrawal handoff rows after reimbursement advances.
- Added reimbursement candidate coverage for complete withdrawals, incomplete-withdrawal gaps, and reimbursement/withdrawal cursor lag.
- Added bridge status response coverage for omitting terminal rows once confirmations reach `max_confirmations`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 

[STR-3295]: https://alpenlabs.atlassian.net/browse/STR-3295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ