### PR TITLE
STR-3057 Add RPC-backed health to UI dashboard

### DIFF
--- a/backend/crates/config/src/lib.rs
+++ b/backend/crates/config/src/lib.rs
@@ -80,6 +80,12 @@ pub struct NetworkMonitoringConfig {
     /// JSON-RPC Endpoint for Strata client and reth
     rpc_url: String,
 
+    /// Optional JSON-RPC endpoint for the Strata EVM client.
+    ///
+    /// Defaults to `rpc_url` when omitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    eth_rpc_url: Option<String>,
+
     /// Bundler health check URL
     bundler_url: String,
 
@@ -104,6 +110,10 @@ impl NetworkMonitoringConfig {
 
     pub fn rpc_url(&self) -> &str {
         &self.rpc_url
+    }
+
+    pub fn eth_rpc_url(&self) -> &str {
+        self.eth_rpc_url.as_deref().unwrap_or(&self.rpc_url)
     }
 
     pub fn bundler_url(&self) -> &str {
@@ -450,6 +460,7 @@ port = 3000
 [network]
 sequencer_url = "https://rpc.testnet.alpenlabs.io"
 rpc_url = "https://rpc.testnet.alpenlabs.io"
+eth_rpc_url = "https://eth-rpc.testnet.alpenlabs.io"
 bundler_url = "https://bundler.testnet.alpenlabs.io/health"
 retry_policy_max_retries = 5
 retry_policy_total_time_s = 60
@@ -587,6 +598,7 @@ port = 8080
 [network]
 sequencer_url = "https://sequencer.example.com"
 rpc_url = "https://rpc.example.com"
+eth_rpc_url = "https://eth-rpc.example.com"
 bundler_url = "https://bundler.example.com/health"
 retry_policy_max_retries = 3
 retry_policy_total_time_s = 30
@@ -647,6 +659,7 @@ withdrawal_denomination_sats = 100000000
             config.network.sequencer_url(),
             "https://sequencer.example.com"
         );
+        assert_eq!(config.network.eth_rpc_url(), "https://eth-rpc.example.com");
         assert_eq!(config.network.status_refetch_interval(), 5);
         assert_eq!(config.network.initial_status_wait_timeout_s(), 4);
         assert_eq!(config.bridge.esplora_url(), "https://esplora.example.com");
@@ -767,6 +780,7 @@ eth_rpc_url = "https://rpc.example.com"
             config.network().initial_status_wait_timeout_s(),
             DEFAULT_NETWORK_INITIAL_STATUS_WAIT_TIMEOUT_S
         );
+        assert_eq!(config.network().eth_rpc_url(), "");
         assert_eq!(
             config.bridge().initial_status_wait_timeout_s(),
             DEFAULT_BRIDGE_INITIAL_STATUS_WAIT_TIMEOUT_S

--- a/backend/crates/network/src/status.rs
+++ b/backend/crates/network/src/status.rs
@@ -1,31 +1,230 @@
+use std::fmt;
+use std::sync::Arc;
+use std::time::Instant;
+
 use anyhow::Result;
 use axum::http::StatusCode;
 use axum::Json;
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::http_client::HttpClient;
-use std::sync::Arc;
-use strata_tasks::ShutdownGuard;
-use tokio::time::{interval, sleep, timeout, Duration};
-use tracing::{error, info};
-
-use super::types::{NetworkMonitoringContext, NetworkStatus, Status};
 use status_config::NetworkMonitoringConfig;
 use status_utils::{create_rpc_client, ExponentialBackoff};
+use strata_tasks::ShutdownGuard;
+use tokio::time::{interval, sleep, timeout, Duration};
+use tracing::{debug, error, info, warn};
 
-/// Calls `strata_syncStatus` using `jsonrpsee`
-async fn call_rpc_status(client: &HttpClient, retry_policy: ExponentialBackoff) -> Status {
+use super::types::{
+    BlockInfoStatus, EpochCommitmentStatus, EvmChainStatus, NetworkMonitoringContext,
+    NetworkStatus, OlChainStatus, Status,
+};
+
+const STRATA_CHAIN_STATUS_METHOD: &str = "strata_getChainStatus";
+const ETH_BLOCK_NUMBER_METHOD: &str = "eth_blockNumber";
+
+#[derive(Debug, PartialEq)]
+enum ChainStatusParseError {
+    MissingField(&'static str),
+    InvalidField(&'static str),
+    InvalidSlotOrder {
+        tip: u64,
+        confirmed: u64,
+        finalized: u64,
+    },
+}
+
+impl fmt::Display for ChainStatusParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingField(field) => write!(f, "missing field `{field}`"),
+            Self::InvalidField(field) => write!(f, "invalid field `{field}`"),
+            Self::InvalidSlotOrder {
+                tip,
+                confirmed,
+                finalized,
+            } => write!(
+                f,
+                "invalid slot order: tip={tip}, confirmed={confirmed}, finalized={finalized}"
+            ),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum EvmStatusParseError {
+    InvalidBlockNumber(String),
+}
+
+impl fmt::Display for EvmStatusParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidBlockNumber(value) => write!(f, "invalid eth block number `{value}`"),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct ProgressTracker {
+    last_value: Option<u64>,
+    last_changed_at: Option<Instant>,
+}
+
+impl ProgressTracker {
+    fn observe(&mut self, value: u64, now: Instant) -> u64 {
+        if self.last_value != Some(value) {
+            self.last_value = Some(value);
+            self.last_changed_at = Some(now);
+            return 0;
+        }
+
+        self.last_changed_at
+            .map(|changed_at| now.saturating_duration_since(changed_at).as_secs())
+            .unwrap_or(0)
+    }
+}
+
+fn read_u64(json: &serde_json::Value, field: &'static str) -> Result<u64, ChainStatusParseError> {
+    json.get(field)
+        .and_then(serde_json::Value::as_u64)
+        .ok_or(ChainStatusParseError::InvalidField(field))
+}
+
+fn read_u32(json: &serde_json::Value, field: &'static str) -> Result<u32, ChainStatusParseError> {
+    let value = read_u64(json, field)?;
+    u32::try_from(value).map_err(|_| ChainStatusParseError::InvalidField(field))
+}
+
+fn read_string(
+    json: &serde_json::Value,
+    field: &'static str,
+) -> Result<String, ChainStatusParseError> {
+    json.get(field)
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned)
+        .ok_or(ChainStatusParseError::InvalidField(field))
+}
+
+fn read_bool(json: &serde_json::Value, field: &'static str) -> Result<bool, ChainStatusParseError> {
+    json.get(field)
+        .and_then(serde_json::Value::as_bool)
+        .ok_or(ChainStatusParseError::InvalidField(field))
+}
+
+fn read_object<'a>(
+    json: &'a serde_json::Value,
+    field: &'static str,
+) -> Result<&'a serde_json::Value, ChainStatusParseError> {
+    json.get(field)
+        .ok_or(ChainStatusParseError::MissingField(field))
+        .and_then(|value| {
+            if value.is_object() {
+                Ok(value)
+            } else {
+                Err(ChainStatusParseError::InvalidField(field))
+            }
+        })
+}
+
+fn parse_block_info(json: &serde_json::Value) -> Result<BlockInfoStatus, ChainStatusParseError> {
+    Ok(BlockInfoStatus::new(
+        read_u64(json, "slot")?,
+        read_string(json, "blkid")?,
+        read_u32(json, "epoch")?,
+        read_bool(json, "is_terminal")?,
+    ))
+}
+
+fn parse_legacy_block_info(
+    json: &serde_json::Value,
+) -> Result<BlockInfoStatus, ChainStatusParseError> {
+    Ok(BlockInfoStatus::new(
+        read_u64(json, "slot")?,
+        read_string(json, "blkid")?,
+        0,
+        false,
+    ))
+}
+
+fn parse_epoch_commitment(
+    json: &serde_json::Value,
+) -> Result<EpochCommitmentStatus, ChainStatusParseError> {
+    Ok(EpochCommitmentStatus::new(
+        read_u32(json, "epoch")?,
+        read_u64(json, "last_slot")?,
+        read_string(json, "last_blkid")?,
+    ))
+}
+
+fn parse_ol_chain_status_response(
+    json: &serde_json::Value,
+) -> Result<OlChainStatus, ChainStatusParseError> {
+    let (tip, latest) = match json.get("tip") {
+        Some(value) if value.is_object() => {
+            let tip = parse_block_info(value)?;
+            let latest = parse_epoch_commitment(read_object(json, "latest")?)?;
+            (tip, latest)
+        }
+        Some(_) => return Err(ChainStatusParseError::InvalidField("tip")),
+        None => match json.get("latest") {
+            Some(value) if value.is_object() => {
+                let tip = parse_legacy_block_info(value)?;
+                let latest = parse_epoch_commitment(read_object(json, "parent")?)?;
+                (tip, latest)
+            }
+            Some(_) => return Err(ChainStatusParseError::InvalidField("latest")),
+            None => return Err(ChainStatusParseError::MissingField("tip")),
+        },
+    };
+    let confirmed = parse_epoch_commitment(read_object(json, "confirmed")?)?;
+    let finalized = parse_epoch_commitment(read_object(json, "finalized")?)?;
+
+    if finalized.last_slot() > confirmed.last_slot() || confirmed.last_slot() > tip.slot() {
+        return Err(ChainStatusParseError::InvalidSlotOrder {
+            tip: tip.slot(),
+            confirmed: confirmed.last_slot(),
+            finalized: finalized.last_slot(),
+        });
+    }
+
+    Ok(OlChainStatus::new(tip, latest, confirmed, finalized))
+}
+
+fn parse_eth_block_number(raw: &str) -> Result<u64, EvmStatusParseError> {
+    let stripped = raw.strip_prefix("0x").unwrap_or(raw);
+    u64::from_str_radix(stripped, 16)
+        .map_err(|_| EvmStatusParseError::InvalidBlockNumber(raw.to_owned()))
+}
+
+/// Calls `strata_getChainStatus` using `jsonrpsee`.
+async fn call_ol_chain_status(
+    client: &HttpClient,
+    retry_policy: ExponentialBackoff,
+    endpoint_name: &'static str,
+) -> (Status, Option<OlChainStatus>) {
     let mut retry_count: u64 = 0;
 
     loop {
-        let response: Result<serde_json::Value, _> =
-            client.request("strata_syncStatus", Vec::<()>::new()).await;
+        let response: Result<serde_json::Value, _> = client
+            .request(STRATA_CHAIN_STATUS_METHOD, Vec::<()>::new())
+            .await;
         match response {
             Ok(json) => {
-                info!(?json, method = "strata_syncStatus", "rpc response");
-                if json.get("tip_height").is_some() {
-                    return Status::Online;
-                } else {
-                    return Status::Offline;
+                debug!(
+                    ?json,
+                    method = STRATA_CHAIN_STATUS_METHOD,
+                    endpoint = endpoint_name,
+                    "rpc response"
+                );
+                match parse_ol_chain_status_response(&json) {
+                    Ok(chain_status) => return (Status::Online, Some(chain_status)),
+                    Err(e) => {
+                        warn!(
+                            error = %e,
+                            method = STRATA_CHAIN_STATUS_METHOD,
+                            endpoint = endpoint_name,
+                            "could not parse OL chain status response"
+                        );
+                        return (Status::Offline, None);
+                    }
                 }
             }
             Err(e) => {
@@ -35,7 +234,8 @@ async fn call_rpc_status(client: &HttpClient, retry_policy: ExponentialBackoff) 
                         info!(
                             delay_seconds,
                             retry_count,
-                            method = "strata_syncStatus",
+                            method = STRATA_CHAIN_STATUS_METHOD,
+                            endpoint = endpoint_name,
                             "retrying rpc status request"
                         );
                         sleep(Duration::from_secs(delay_seconds)).await;
@@ -44,10 +244,62 @@ async fn call_rpc_status(client: &HttpClient, retry_policy: ExponentialBackoff) 
                 } else {
                     error!(
                         error = %e,
-                        method = "strata_syncStatus",
-                        "could not get network status"
+                        method = STRATA_CHAIN_STATUS_METHOD,
+                        endpoint = endpoint_name,
+                        "could not get OL chain status"
                     );
-                    return Status::Offline;
+                    return (Status::Offline, None);
+                }
+            }
+        }
+    }
+}
+
+/// Calls `eth_blockNumber` using `jsonrpsee`.
+async fn call_evm_chain_status(
+    client: &HttpClient,
+    retry_policy: ExponentialBackoff,
+) -> (Status, Option<EvmChainStatus>) {
+    let mut retry_count: u64 = 0;
+
+    loop {
+        let response: Result<String, _> = client
+            .request(ETH_BLOCK_NUMBER_METHOD, Vec::<()>::new())
+            .await;
+        match response {
+            Ok(raw) => match parse_eth_block_number(&raw) {
+                Ok(block_number) => {
+                    return (Status::Online, Some(EvmChainStatus::new(block_number)));
+                }
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        method = ETH_BLOCK_NUMBER_METHOD,
+                        "could not parse EVM chain status response"
+                    );
+                    return (Status::Offline, None);
+                }
+            },
+            Err(e) => {
+                if retry_count < retry_policy.max_retries() {
+                    let delay_seconds = retry_policy.get_delay(retry_count);
+                    if delay_seconds > 0 {
+                        info!(
+                            delay_seconds,
+                            retry_count,
+                            method = ETH_BLOCK_NUMBER_METHOD,
+                            "retrying EVM rpc status request"
+                        );
+                        sleep(Duration::from_secs(delay_seconds)).await;
+                    }
+                    retry_count += 1;
+                } else {
+                    error!(
+                        error = %e,
+                        method = ETH_BLOCK_NUMBER_METHOD,
+                        "could not get EVM chain status"
+                    );
+                    return (Status::Offline, None);
                 }
             }
         }
@@ -60,13 +312,30 @@ async fn check_bundler_health(
     config: &NetworkMonitoringConfig,
 ) -> Status {
     let url = config.bundler_url();
-    if let Ok(resp) = client.get(url).send().await {
-        let body = resp.text().await.unwrap_or_default();
-        if body.contains("ok") {
-            return Status::Online;
+    match client.get(url).send().await {
+        Ok(resp) => {
+            let status = resp.status();
+            match resp.text().await {
+                Ok(body) if body.contains("ok") => Status::Online,
+                Ok(_) => {
+                    warn!(
+                        url,
+                        %status,
+                        "bundler health response did not contain expected status"
+                    );
+                    Status::Offline
+                }
+                Err(e) => {
+                    error!(url, error = %e, "could not read bundler health response body");
+                    Status::Offline
+                }
+            }
+        }
+        Err(e) => {
+            error!(url, error = %e, "could not query bundler health endpoint");
+            Status::Offline
         }
     }
-    Status::Offline
 }
 
 /// Periodically polls configured network service endpoints and updates status state.
@@ -80,7 +349,11 @@ pub async fn network_monitoring_task(
     ));
     let sequencer_client = create_rpc_client(context.config().sequencer_url());
     let rpc_client = create_rpc_client(context.config().rpc_url());
+    let eth_rpc_client = create_rpc_client(context.config().eth_rpc_url());
     let http_client = reqwest::Client::new();
+    let mut sequencer_ol_progress = ProgressTracker::default();
+    let mut rpc_ol_progress = ProgressTracker::default();
+    let mut ee_progress = ProgressTracker::default();
 
     loop {
         tokio::select! {
@@ -88,12 +361,48 @@ pub async fn network_monitoring_task(
             _ = interval.tick() => {}
         }
 
-        let sequencer =
-            call_rpc_status(&sequencer_client, context.config().sequencer_retry_policy()).await;
-        let rpc_endpoint = call_rpc_status(&rpc_client, context.config().rpc_retry_policy()).await;
+        let (sequencer, mut sequencer_chain) = call_ol_chain_status(
+            &sequencer_client,
+            context.config().sequencer_retry_policy(),
+            "sequencer",
+        )
+        .await;
+        let (rpc_endpoint, mut rpc_chain) = call_ol_chain_status(
+            &rpc_client,
+            context.config().rpc_retry_policy(),
+            "rpc_endpoint",
+        )
+        .await;
+        let (ee_endpoint, mut ee_chain) =
+            call_evm_chain_status(&eth_rpc_client, context.config().rpc_retry_policy()).await;
         let bundler_endpoint = check_bundler_health(&http_client, context.config()).await;
 
-        let new_status = NetworkStatus::new(sequencer, rpc_endpoint, bundler_endpoint);
+        let now = Instant::now();
+        if let Some(chain) = &mut sequencer_chain {
+            chain.set_latest_slot_stale_seconds(Some(
+                sequencer_ol_progress.observe(chain.latest_slot(), now),
+            ));
+        }
+        if let Some(chain) = &mut rpc_chain {
+            chain.set_latest_slot_stale_seconds(Some(
+                rpc_ol_progress.observe(chain.latest_slot(), now),
+            ));
+        }
+        if let Some(chain) = &mut ee_chain {
+            chain.set_latest_block_stale_seconds(Some(
+                ee_progress.observe(chain.latest_block_number(), now),
+            ));
+        }
+
+        let new_status = NetworkStatus::new(
+            sequencer,
+            rpc_endpoint,
+            ee_endpoint,
+            bundler_endpoint,
+            sequencer_chain,
+            rpc_chain,
+            ee_chain,
+        );
 
         info!(?new_status, "updated network status");
 
@@ -120,4 +429,141 @@ pub async fn get_network_status(
     }
 
     Ok(Json(context.status().await))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use serde_json::json;
+
+    use super::{
+        parse_eth_block_number, parse_ol_chain_status_response, ChainStatusParseError,
+        ProgressTracker,
+    };
+
+    fn block_id(seed: u8) -> String {
+        format!("{seed:02x}").repeat(32)
+    }
+
+    fn chain_status_json(latest: u64, confirmed: u64, finalized: u64) -> serde_json::Value {
+        json!({
+            "tip": {
+                "slot": latest,
+                "blkid": block_id(1),
+                "epoch": 12,
+                "is_terminal": false
+            },
+            "latest": {
+                "epoch": 12,
+                "last_slot": latest.saturating_sub(1),
+                "last_blkid": block_id(2)
+            },
+            "confirmed": {
+                "epoch": 12,
+                "last_slot": confirmed,
+                "last_blkid": block_id(3)
+            },
+            "finalized": {
+                "epoch": 10,
+                "last_slot": finalized,
+                "last_blkid": block_id(4)
+            }
+        })
+    }
+
+    #[test]
+    fn parses_current_ol_chain_status_response() {
+        let parsed = parse_ol_chain_status_response(&chain_status_json(120, 100, 80))
+            .expect("current chain status shape should parse");
+        let serialized = serde_json::to_value(parsed).expect("status should serialize");
+
+        assert_eq!(serialized["tip"]["slot"], 120);
+        assert_eq!(serialized["tip"]["epoch"], 12);
+        assert_eq!(serialized["latest"]["last_slot"], 119);
+        assert_eq!(serialized["confirmed"]["last_slot"], 100);
+        assert_eq!(serialized["finalized"]["last_slot"], 80);
+        assert_eq!(serialized["confirmation_lag_slots"], 20);
+        assert_eq!(serialized["finality_lag_slots"], 40);
+    }
+
+    #[test]
+    fn parses_legacy_ol_chain_status_response() {
+        let parsed = parse_ol_chain_status_response(&json!({
+            "latest": {
+                "slot": 120,
+                "blkid": block_id(1)
+            },
+            "parent": {
+                "epoch": 12,
+                "last_slot": 110,
+                "last_blkid": block_id(2)
+            },
+            "confirmed": {
+                "epoch": 12,
+                "last_slot": 100,
+                "last_blkid": block_id(3)
+            },
+            "finalized": {
+                "epoch": 10,
+                "last_slot": 80,
+                "last_blkid": block_id(4)
+            }
+        }))
+        .expect("legacy chain status shape should parse");
+        let serialized = serde_json::to_value(parsed).expect("status should serialize");
+
+        assert_eq!(serialized["tip"]["slot"], 120);
+        assert_eq!(serialized["latest"]["last_slot"], 110);
+        assert_eq!(serialized["confirmed"]["last_slot"], 100);
+        assert_eq!(serialized["finalized"]["last_slot"], 80);
+    }
+
+    #[test]
+    fn rejects_ol_chain_status_without_tip_or_latest() {
+        let err = parse_ol_chain_status_response(&json!({
+            "parent": {},
+            "confirmed": {},
+            "finalized": {}
+        }))
+        .expect_err("missing tip/latest status must fail");
+
+        assert_eq!(err, ChainStatusParseError::MissingField("tip"));
+    }
+
+    #[test]
+    fn rejects_invalid_ol_slot_order() {
+        let err = parse_ol_chain_status_response(&chain_status_json(100, 120, 80))
+            .expect_err("confirmed slot cannot exceed latest slot");
+
+        assert_eq!(
+            err,
+            ChainStatusParseError::InvalidSlotOrder {
+                tip: 100,
+                confirmed: 120,
+                finalized: 80,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_eth_block_number_hex() {
+        assert_eq!(parse_eth_block_number("0x10").unwrap(), 16);
+        assert_eq!(parse_eth_block_number("10").unwrap(), 16);
+    }
+
+    #[test]
+    fn rejects_invalid_eth_block_number_hex() {
+        assert!(parse_eth_block_number("nope").is_err());
+    }
+
+    #[test]
+    fn progress_tracker_resets_when_value_changes() {
+        let mut tracker = ProgressTracker::default();
+        let start = std::time::Instant::now();
+
+        assert_eq!(tracker.observe(10, start), 0);
+        assert_eq!(tracker.observe(10, start + Duration::from_secs(3)), 3);
+        assert_eq!(tracker.observe(11, start + Duration::from_secs(4)), 0);
+    }
 }

--- a/backend/crates/network/src/types.rs
+++ b/backend/crates/network/src/types.rs
@@ -5,7 +5,7 @@ use tokio::time::Duration;
 
 use status_config::NetworkMonitoringConfig;
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum Status {
     Online,
@@ -16,7 +16,11 @@ pub(crate) enum Status {
 pub struct NetworkStatus {
     sequencer: Status,
     rpc_endpoint: Status,
+    ee_endpoint: Status,
     bundler_endpoint: Status,
+    sequencer_chain: Option<OlChainStatus>,
+    rpc_chain: Option<OlChainStatus>,
+    ee_chain: Option<EvmChainStatus>,
 }
 
 impl Default for NetworkStatus {
@@ -24,18 +28,143 @@ impl Default for NetworkStatus {
         Self {
             sequencer: Status::Offline,
             rpc_endpoint: Status::Offline,
+            ee_endpoint: Status::Offline,
             bundler_endpoint: Status::Offline,
+            sequencer_chain: None,
+            rpc_chain: None,
+            ee_chain: None,
         }
     }
 }
 
 impl NetworkStatus {
-    pub(crate) fn new(sequencer: Status, rpc_endpoint: Status, bundler_endpoint: Status) -> Self {
+    pub(crate) fn new(
+        sequencer: Status,
+        rpc_endpoint: Status,
+        ee_endpoint: Status,
+        bundler_endpoint: Status,
+        sequencer_chain: Option<OlChainStatus>,
+        rpc_chain: Option<OlChainStatus>,
+        ee_chain: Option<EvmChainStatus>,
+    ) -> Self {
         Self {
             sequencer,
             rpc_endpoint,
+            ee_endpoint,
             bundler_endpoint,
+            sequencer_chain,
+            rpc_chain,
+            ee_chain,
         }
+    }
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq)]
+pub struct BlockInfoStatus {
+    slot: u64,
+    block_id: String,
+    epoch: u32,
+    is_terminal: bool,
+}
+
+impl BlockInfoStatus {
+    pub(crate) fn new(slot: u64, block_id: String, epoch: u32, is_terminal: bool) -> Self {
+        Self {
+            slot,
+            block_id,
+            epoch,
+            is_terminal,
+        }
+    }
+
+    pub(crate) fn slot(&self) -> u64 {
+        self.slot
+    }
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq)]
+pub struct EpochCommitmentStatus {
+    epoch: u32,
+    last_slot: u64,
+    last_block_id: String,
+}
+
+impl EpochCommitmentStatus {
+    pub(crate) fn new(epoch: u32, last_slot: u64, last_block_id: String) -> Self {
+        Self {
+            epoch,
+            last_slot,
+            last_block_id,
+        }
+    }
+
+    pub(crate) fn last_slot(&self) -> u64 {
+        self.last_slot
+    }
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq)]
+pub struct OlChainStatus {
+    tip: BlockInfoStatus,
+    latest: EpochCommitmentStatus,
+    confirmed: EpochCommitmentStatus,
+    finalized: EpochCommitmentStatus,
+    confirmation_lag_slots: u64,
+    finality_lag_slots: u64,
+    latest_slot_stale_seconds: Option<u64>,
+}
+
+impl OlChainStatus {
+    pub(crate) fn new(
+        tip: BlockInfoStatus,
+        latest: EpochCommitmentStatus,
+        confirmed: EpochCommitmentStatus,
+        finalized: EpochCommitmentStatus,
+    ) -> Self {
+        let latest_slot = tip.slot();
+        let confirmed_slot = confirmed.last_slot();
+        let finalized_slot = finalized.last_slot();
+
+        Self {
+            tip,
+            latest,
+            confirmed,
+            finalized,
+            confirmation_lag_slots: latest_slot.saturating_sub(confirmed_slot),
+            finality_lag_slots: latest_slot.saturating_sub(finalized_slot),
+            latest_slot_stale_seconds: None,
+        }
+    }
+
+    pub(crate) fn latest_slot(&self) -> u64 {
+        self.tip.slot()
+    }
+
+    pub(crate) fn set_latest_slot_stale_seconds(&mut self, seconds: Option<u64>) {
+        self.latest_slot_stale_seconds = seconds;
+    }
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq)]
+pub struct EvmChainStatus {
+    latest_block_number: u64,
+    latest_block_stale_seconds: Option<u64>,
+}
+
+impl EvmChainStatus {
+    pub(crate) fn new(latest_block_number: u64) -> Self {
+        Self {
+            latest_block_number,
+            latest_block_stale_seconds: None,
+        }
+    }
+
+    pub(crate) fn latest_block_number(&self) -> u64 {
+        self.latest_block_number
+    }
+
+    pub(crate) fn set_latest_block_stale_seconds(&mut self, seconds: Option<u64>) {
+        self.latest_block_stale_seconds = seconds;
     }
 }
 

--- a/backend/example-config.toml
+++ b/backend/example-config.toml
@@ -12,6 +12,7 @@ datadir = "data"
   initial_status_wait_timeout_s = 30
   retry_policy_max_retries      = 5
   retry_policy_total_time_s     = 60
+  eth_rpc_url                   = "https://rpc.testnet.alpenlabs.io"
   rpc_url                       = "https://rpc.testnet.alpenlabs.io"
   sequencer_url                 = "https://rpc.testnet.alpenlabs.io"
   status_refetch_interval_s     = 10

--- a/frontend/src/components/StatusCard.tsx
+++ b/frontend/src/components/StatusCard.tsx
@@ -1,9 +1,13 @@
 interface StatusCardProps {
   title: string;
   status: string;
+  details?: Array<{
+    label: string;
+    value: string | number;
+  }>;
 }
 
-const StatusCard = ({ title, status }: StatusCardProps) => {
+const StatusCard = ({ title, status, details = [] }: StatusCardProps) => {
   return (
     <div className="status-section">
       <div className="status-title">{title.toUpperCase()}</div>
@@ -11,6 +15,16 @@ const StatusCard = ({ title, status }: StatusCardProps) => {
         <span className={`status-text ${status.toLowerCase()}`}>
           {status.toUpperCase()}
         </span>
+        {details.length > 0 && (
+          <dl className="status-details">
+            {details.map(detail => (
+              <div className="status-detail-row" key={detail.label}>
+                <dt>{detail.label}</dt>
+                <dd>{detail.value}</dd>
+              </div>
+            ))}
+          </dl>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/hooks/useNetworkStatus.ts
+++ b/frontend/src/hooks/useNetworkStatus.ts
@@ -4,7 +4,39 @@ import { useConfig } from './useConfig';
 export type NetworkStatus = {
   sequencer: string;
   rpc_endpoint: string;
+  ee_endpoint?: string;
   bundler_endpoint: string;
+  sequencer_chain?: OlChainStatus | null;
+  rpc_chain?: OlChainStatus | null;
+  ee_chain?: EvmChainStatus | null;
+};
+
+export type BlockInfoStatus = {
+  slot: number;
+  block_id: string;
+  epoch: number;
+  is_terminal: boolean;
+};
+
+export type EpochCommitmentStatus = {
+  epoch: number;
+  last_slot: number;
+  last_block_id: string;
+};
+
+export type OlChainStatus = {
+  tip: BlockInfoStatus;
+  latest: EpochCommitmentStatus;
+  confirmed: EpochCommitmentStatus;
+  finalized: EpochCommitmentStatus;
+  confirmation_lag_slots: number;
+  finality_lag_slots: number;
+  latest_slot_stale_seconds?: number | null;
+};
+
+export type EvmChainStatus = {
+  latest_block_number: number;
+  latest_block_stale_seconds?: number | null;
 };
 
 const fetchNetworkStatus = async (baseUrl: string): Promise<NetworkStatus> => {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,11 +1,78 @@
 import { lazy, Suspense, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
+import type { EvmChainStatus, OlChainStatus } from '../hooks/useNetworkStatus';
 import { useNetworkStatus } from '../hooks/useNetworkStatus';
 import '../styles/network.css';
 
 const StatusCard = lazy(() => import('../components/StatusCard'));
 const Bridge = lazy(() => import('./Bridge'));
 const Balances = lazy(() => import('./Balances'));
+
+const formatStatus = (status?: string) => status?.toUpperCase() ?? 'UNKNOWN';
+
+const formatNumber = (value?: number | null) =>
+  value == null ? 'Unknown' : value.toLocaleString();
+
+const formatStaleSeconds = (value?: number | null) =>
+  value == null ? 'Unknown' : `${value.toLocaleString()}s`;
+
+const formatSlotLag = (value?: number | null) =>
+  value == null ? 'Unknown' : `${value.toLocaleString()} slots`;
+
+const olChainDetails = (chain?: OlChainStatus | null) => [
+  {
+    label: 'Tip slot',
+    value: formatNumber(chain?.tip.slot),
+  },
+  {
+    label: 'Tip epoch',
+    value: formatNumber(chain?.tip.epoch),
+  },
+  {
+    label: 'Latest epoch',
+    value:
+      chain == null
+        ? 'Unknown'
+        : `epoch ${chain.latest.epoch} / slot ${chain.latest.last_slot.toLocaleString()}`,
+  },
+  {
+    label: 'Confirmed',
+    value:
+      chain == null
+        ? 'Unknown'
+        : `epoch ${chain.confirmed.epoch} / slot ${chain.confirmed.last_slot.toLocaleString()}`,
+  },
+  {
+    label: 'Finalized',
+    value:
+      chain == null
+        ? 'Unknown'
+        : `epoch ${chain.finalized.epoch} / slot ${chain.finalized.last_slot.toLocaleString()}`,
+  },
+  {
+    label: 'Confirm lag',
+    value: formatSlotLag(chain?.confirmation_lag_slots),
+  },
+  {
+    label: 'Finality lag',
+    value: formatSlotLag(chain?.finality_lag_slots),
+  },
+  {
+    label: 'Last progressed',
+    value: formatStaleSeconds(chain?.latest_slot_stale_seconds),
+  },
+];
+
+const evmChainDetails = (chain?: EvmChainStatus | null) => [
+  {
+    label: 'Latest block',
+    value: formatNumber(chain?.latest_block_number),
+  },
+  {
+    label: 'Last progressed',
+    value: formatStaleSeconds(chain?.latest_block_stale_seconds),
+  },
+];
 
 export default function Dashboard() {
   const [isMenuOpen, setMenuOpen] = useState(false);
@@ -76,19 +143,49 @@ export default function Dashboard() {
               {isLoading ? (
                 <p className="loading-text">Loading...</p>
               ) : (
-                <div className="status-cards">
-                  <StatusCard
-                    title="Sequencer status"
-                    status={data?.sequencer.toUpperCase() ?? 'Unknown'}
-                  />
-                  <StatusCard
-                    title="RPC endpoint status"
-                    status={data?.rpc_endpoint.toUpperCase() ?? 'Unknown'}
-                  />
-                  <StatusCard
-                    title="Bundler endpoint status"
-                    status={data?.bundler_endpoint.toUpperCase() ?? 'Unknown'}
-                  />
+                <div className="network-sections">
+                  <section className="network-section">
+                    <h2 className="network-section-title">Service endpoints</h2>
+                    <div className="status-cards">
+                      <StatusCard
+                        title="Sequencer"
+                        status={formatStatus(data?.sequencer)}
+                      />
+                      <StatusCard
+                        title="OL RPC"
+                        status={formatStatus(data?.rpc_endpoint)}
+                      />
+                      <StatusCard
+                        title="EE RPC"
+                        status={formatStatus(data?.ee_endpoint)}
+                      />
+                      <StatusCard
+                        title="Bundler"
+                        status={formatStatus(data?.bundler_endpoint)}
+                      />
+                    </div>
+                  </section>
+
+                  <section className="network-section">
+                    <h2 className="network-section-title">Chain production</h2>
+                    <div className="status-cards">
+                      <StatusCard
+                        title="Sequencer OL"
+                        status={formatStatus(data?.sequencer)}
+                        details={olChainDetails(data?.sequencer_chain)}
+                      />
+                      <StatusCard
+                        title="Public OL RPC"
+                        status={formatStatus(data?.rpc_endpoint)}
+                        details={olChainDetails(data?.rpc_chain)}
+                      />
+                      <StatusCard
+                        title="EE blocks"
+                        status={formatStatus(data?.ee_endpoint)}
+                        details={evmChainDetails(data?.ee_chain)}
+                      />
+                    </div>
+                  </section>
                 </div>
               )}
             </Suspense>

--- a/frontend/src/styles/network.css
+++ b/frontend/src/styles/network.css
@@ -1,34 +1,47 @@
-.status-cards {
+.network-sections {
   display: flex;
-  flex-direction: row;
-  text-align: center;
-  gap: 8px;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.network-section {
+  color: black;
+}
+
+.network-section-title {
+  margin: 0 0 20px;
+  color: black;
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+.status-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
 }
 
 .status-section {
-  justify-content: space-between;
-  margin: 0 10px;
-  padding: 10px 10px;
-  width: 33%;
+  min-width: 0;
   text-align: left;
 }
 
 .status-title,
 .title {
-  margin: 0 1rem;
+  margin: 0 0 8px;
   color: black;
   font-weight: 600;
 }
 
 .status-value {
-  padding: 2rem 10px;
-  margin: 0.5rem auto;
+  min-height: 96px;
+  padding: 24px 16px;
   border: 0.5px solid rgba(113, 128, 150, 1);
   box-shadow: 0px 4px 11px 0px rgba(0, 0, 0, 0.08);
-  border-radius: 10px;
+  border-radius: 8px;
   font-weight: bold;
   color: black;
-  text-align: center;
+  text-align: left;
 }
 
 .status-text.online {
@@ -39,15 +52,54 @@
   color: red;
 }
 
+.status-text.unknown {
+  color: #718096;
+}
+
+.status-details {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 18px 0 0;
+  font-weight: 400;
+}
+
+.status-detail-row {
+  display: grid;
+  grid-template-columns: minmax(90px, 1fr) minmax(0, 1.2fr);
+  gap: 12px;
+  align-items: baseline;
+}
+
+.status-detail-row dt {
+  color: #4a5568;
+  font-size: 13px;
+}
+
+.status-detail-row dd {
+  min-width: 0;
+  margin: 0;
+  color: black;
+  font-size: 14px;
+  overflow-wrap: anywhere;
+  text-align: right;
+}
+
 @media screen and (max-width: 768px) {
-  .status-cards {
-    flex-wrap: wrap;
-    justify-content: center;
+  .network-sections {
+    padding: 0 16px;
   }
 
-  .status-section {
-    flex: 1 1 100%;
-    width: 100%;
-    box-sizing: border-box;
+  .status-cards {
+    grid-template-columns: 1fr;
+  }
+
+  .status-detail-row {
+    grid-template-columns: 1fr;
+    gap: 2px;
+  }
+
+  .status-detail-row dd {
+    text-align: left;
   }
 }


### PR DESCRIPTION
## Summary
- switch the UI dashboard network health check from simple endpoint presence to RPC-backed OL/EE chain status
- call `strata_getChainStatus` for OL endpoints and `eth_blockNumber` for the EE endpoint
- expose tip/latest/confirmed/finalized slots, lag, and stale-progress timing in the dashboard cards
- add explicit parse errors/logging instead of silently treating malformed RPC responses as healthy

## Context
This is the UI/internal dashboard companion to the Grafana dashboard work in `deployments`. It is intentionally separate from the Grafana PR so review can keep the two surfaces distinct.

This PR targets `internal-dashboard`, not `main`, because this work builds on the internal dashboard branch history.

## Validation
- `cargo test -p status-network`
- `PATH="/opt/homebrew/bin:$PATH" npm run build`
- `git diff --check`
- checked for stale frontend/backend references to the old `latest/parent` OL shape

## Notes
- STR-3057: https://alpenlabs.atlassian.net/browse/STR-3057
- Parser supports the deployed `tip/latest/confirmed/finalized` OL response shape, with a legacy fallback for the older `latest/parent` shape.
