### PR TITLE
fix(bridge): handle failed deposits in withdrawal pairing

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -14,8 +14,9 @@ dependencies = [
 [[package]]
 name = "algebra"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=0ecec67b67db89f6b761ffeaa09af8e7ad864bb1#0ecec67b67db89f6b761ffeaa09af8e7ad864bb1"
+source = "git+https://github.com/alpenlabs/strata-bridge.git?tag=v0.3.0-rc.1#089ed5d25cc54c31b0c53df6807c7a2cfb48bc38"
 dependencies = [
+ "cfg-if",
  "futures",
  "proptest",
  "tokio",
@@ -23,9 +24,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9dbe713da0c737d9e5e387b0ba790eb98b14dd207fe53eef50e19a5a8ec3dac"
+checksum = "7c36c9d7f9021601b04bfef14a4b64849f6d73116a4e91e071d7fbfe10247901"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -35,17 +36,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3b431b4e72cd8bd0ec7a50b4be18e73dab74de0dba180eef171055e5d5926e"
+checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
  "derive_more",
- "foldhash 0.2.0",
- "hashbrown 0.16.1",
+ "foldhash",
+ "hashbrown 0.17.1",
  "indexmap",
  "itoa",
  "k256",
@@ -56,6 +57,7 @@ dependencies = [
  "rapidhash",
  "ruint",
  "rustc-hash",
+ "secp256k1 0.31.1",
  "serde",
  "sha3",
 ]
@@ -72,23 +74,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab81bab693da9bb79f7a95b64b394718259fdd7e41dceeced4cad57cb71c4f6a"
+checksum = "840128ed2b2971d6d4668a553fe403a82683d3acc646c73e75887e7157408033"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489f1620bb7e2483fb5819ed01ab6edc1d2f93939dce35a5695085a1afd1d699"
+checksum = "63ec265e5d65d725175f6ca7711c970824c90ef9c0d1f1973711d4150ee612dd"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -98,15 +100,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha3",
- "syn 2.0.117",
+ "syn 2.0.118",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56cef806ad22d4392c5fc83cf8f2089f988eb99c7067b4e0c6f1971fc1cca318"
+checksum = "89bf01077f18650876cfa682eb1f949967b5cde03f1a51c955c469d2c9b4aa67"
 dependencies = [
  "const-hex",
  "dunce",
@@ -114,25 +116,25 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6df77fea9d6a2a75c0ef8d2acbdfd92286cc599983d3175ccdc170d3433d249"
+checksum = "857b470ecdd2ed38beaf82ad1a38c516a8ff75266750f38b9eeed001d575241b"
 dependencies = [
  "serde",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64612d29379782a5dde6f4b6570d9c756d734d760c0c94c254d361e678a6591f"
+checksum = "384cf252de0db2dec52821eac037a7f57e2aa33fe5b900ce6fe39973402341f1"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -143,7 +145,7 @@ dependencies = [
 [[package]]
 name = "alpen-reth-primitives"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/alpen.git?rev=2c6ae209dd5f2ed71e6f9f7b721ea7ab21190e10#2c6ae209dd5f2ed71e6f9f7b721ea7ab21190e10"
+source = "git+https://github.com/alpenlabs/alpen.git?tag=v0.3.0-rc.1#e63783002c12b5e61891cf1b04c341cbf0f31bd3"
 dependencies = [
  "alloy-sol-types",
  "serde",
@@ -251,7 +253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -289,7 +291,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -319,7 +321,6 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive",
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
@@ -327,14 +328,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-serialize-derive"
-version = "0.5.0"
+name = "ark-serialize"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -368,6 +381,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,9 +398,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "async-trait"
@@ -387,7 +410,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -404,20 +427,20 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -425,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -495,11 +518,10 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base58ck"
-version = "0.1.0"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+checksum = "365c0acd5b2e8dd0111a46c4faea83fb3cfb6e39a49a7c73a06e090db7b2eff0"
 dependencies = [
- "bitcoin-internals",
  "bitcoin_hashes",
 ]
 
@@ -547,19 +569,18 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitcoin"
-version = "0.32.8"
+version = "0.32.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
+checksum = "8ed8ccb78a9ff7a6fbb90e2fb9b8588b4a9928d49d8af3cb789108a84ea6b0ce"
 dependencies = [
  "base58ck",
  "bech32",
- "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
  "bitcoin_hashes",
- "hex-conservative",
+ "hex-conservative 0.2.2",
  "hex_lit",
- "secp256k1",
+ "secp256k1 0.29.1",
  "serde",
 ]
 
@@ -570,39 +591,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94fb19ad225b5555a3c99796fe9c5d14b18eb0130eee5c39875bb642f173be6f"
 dependencies = [
  "bitcoin",
- "hex-conservative",
- "secp256k1",
+ "hex-conservative 0.2.2",
+ "secp256k1 0.29.1",
 ]
 
 [[package]]
 name = "bitcoin-bosd"
-version = "0.10.0"
-source = "git+https://github.com/alpenlabs/bitcoin-bosd?tag=v0.10.0#a55e1e7c85a4d2ce12a8f9a3f875f10996ccc495"
+version = "0.11.0"
+source = "git+https://github.com/alpenlabs/bitcoin-bosd?tag=v0.11.0#2fc97b87088059762ead689cb67d8f118aa86160"
 dependencies = [
  "arbitrary",
  "bitcoin",
  "borsh",
- "hex-conservative",
- "secp256k1",
+ "hex-conservative 0.2.2",
+ "secp256k1 0.29.1",
  "serde",
  "ssz",
  "ssz_types",
 ]
 
 [[package]]
-name = "bitcoin-internals"
-version = "0.3.0"
+name = "bitcoin-consensus-encoding"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
 dependencies = [
- "serde",
+ "bitcoin-internals",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
+dependencies = [
+ "hex-conservative 0.3.2",
 ]
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.4"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
+dependencies = [
+ "bitcoin-consensus-encoding",
+]
 
 [[package]]
 name = "bitcoin-script"
@@ -616,22 +649,22 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.3"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346568ebaab2918487cea76dd55dae13c27bb618cdb737c952e69eb2017c4118"
+checksum = "9cb95693f371d089a4b5b6fc41c6f3ea6e01ee8c15388335dfac8ea685173b51"
 dependencies = [
- "bitcoin-internals",
+ "bitcoin-consensus-encoding",
  "serde",
 ]
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
 dependencies = [
  "bitcoin-io",
- "hex-conservative",
+ "hex-conservative 0.2.2",
  "serde",
 ]
 
@@ -643,15 +676,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -684,10 +717,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "borsh"
-version = "1.6.1"
+name = "block-buffer"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "borsh"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
 dependencies = [
  "borsh-derive",
  "bytes",
@@ -696,22 +738,22 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-slice-cast"
@@ -739,7 +781,7 @@ checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -750,18 +792,18 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -808,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.19.0"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -957,6 +999,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,14 +1031,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -995,34 +1046,33 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1061,7 +1111,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1083,7 +1133,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -1102,21 +1152,31 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
+name = "digest"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1172,14 +1232,14 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -1226,7 +1286,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1312,12 +1372,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1412,7 +1466,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1429,9 +1483,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 dependencies = [
  "gloo-timers",
  "send_wrapper",
@@ -1503,15 +1557,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1537,9 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1573,9 +1625,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1598,29 +1650,14 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "foldhash 0.2.0",
+ "foldhash",
  "serde",
  "serde_core",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -1642,6 +1679,24 @@ name = "hex-conservative"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35431185f361ccf3ffc58254628af5f1f5d5f28531da2e02e5d6c82bbc282a10"
 dependencies = [
  "arrayvec",
 ]
@@ -1672,9 +1727,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1716,10 +1771,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "hyper"
-version = "1.9.0"
+name = "hybrid-array"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1861,12 +1925,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1910,7 +1968,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1920,7 +1978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1943,7 +2001,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1951,16 +2009,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "itertools"
@@ -1976,6 +2024,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2029,7 +2086,7 @@ dependencies = [
  "quote",
  "rustc_version 0.4.1",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2057,7 +2114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2072,13 +2129,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2186,7 +2242,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2270,18 +2326,19 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa468878266ad91431012b3e5ef1bf9b170eab22883503a318d46857afa4579a"
+checksum = "dd5dc2c0d691cbf7595cde551ced329cca99c2387c2cbc97754c5d0cd045d3ee"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -2312,12 +2369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,13 +2382,13 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c7892c221730ba55f7196e98b0b8ba5e04b4155651736036628e9f73ed6fc3"
+checksum = "9525f3831544f7ae497bde79adf114ef127b0fbbb97edbbf692a80408636421c"
 dependencies = [
  "ed25519-dalek",
  "hkdf",
- "quick-protobuf",
+ "prost",
  "sha2",
  "tracing",
  "zeroize",
@@ -2366,9 +2417,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -2378,13 +2429,13 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "macro-string"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2404,9 +2455,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mime"
@@ -2416,19 +2467,20 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniscript"
-version = "12.3.6"
+version = "13.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c14116d8342edd3626b0f8e84df16f4e6a76dc04799ba747493403236a1b8ac5"
+checksum = "cd35e2c377504e50159561884b03610711db6c2fec6c89f2b98d94016684726b"
 dependencies = [
  "bech32",
  "bitcoin",
+ "hex-conservative 1.2.0",
 ]
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -2438,9 +2490,9 @@ dependencies = [
 [[package]]
 name = "mosaic-common"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=0fc9ba8d2359c7509b8ebf65e8aa5d423704b505#0fc9ba8d2359c7509b8ebf65e8aa5d423704b505"
+source = "git+https://github.com/alpenlabs/mosaic?rev=6a85547cc8d4d408eaa7e1aa121a285e7813430f#6a85547cc8d4d408eaa7e1aa121a285e7813430f"
 dependencies = [
- "ark-serialize 0.5.0",
+ "ark-serialize 0.6.0",
  "serde",
 ]
 
@@ -2461,22 +2513,7 @@ checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "musig2"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baebdafa62ee63bfbb09d9e9664e9f8ba3f5765efcc813c97a92aebdaa06b8a5"
-dependencies = [
- "base16ct",
- "hmac",
- "once_cell",
- "secp",
- "secp256k1",
- "sha2",
- "subtle",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2489,9 +2526,24 @@ dependencies = [
  "once_cell",
  "rand 0.8.6",
  "secp",
- "secp256k1",
+ "secp256k1 0.29.1",
  "serde",
  "serdect 0.3.0",
+ "sha2",
+ "subtle",
+]
+
+[[package]]
+name = "musig2"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133feb642b69e836f314b6482d1b7d7c90f9c1c19080689af42a8c288f57d5bf"
+dependencies = [
+ "base16ct",
+ "hmac",
+ "once_cell",
+ "secp",
+ "secp256k1 0.29.1",
  "sha2",
  "subtle",
 ]
@@ -2535,28 +2587,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
-dependencies = [
- "num_enum_derive",
- "rustversion",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2593,7 +2623,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2668,22 +2698,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2727,7 +2757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2747,7 +2777,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2793,7 +2823,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2813,7 +2843,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "version_check",
 ]
 
@@ -2825,7 +2855,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -2844,7 +2874,30 @@ checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2864,7 +2917,7 @@ checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2874,19 +2927,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quick-protobuf"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2904,9 +2948,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -2935,14 +2979,14 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -3068,7 +3112,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3084,9 +3128,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rend"
@@ -3099,9 +3143,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -3169,7 +3213,7 @@ checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
 dependencies = [
  "bytecheck",
  "bytes",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "indexmap",
  "munge",
  "ptr_meta",
@@ -3188,7 +3232,7 @@ checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3277,7 +3321,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3286,9 +3330,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3302,9 +3346,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -3360,7 +3404,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-root-certs 1.0.7",
+ "webpki-root-certs 1.0.8",
  "windows-sys 0.61.2",
 ]
 
@@ -3464,7 +3508,7 @@ dependencies = [
  "base16ct",
  "once_cell",
  "rand 0.8.6",
- "secp256k1",
+ "secp256k1 0.29.1",
  "serde",
  "serdect 0.2.0",
  "subtle",
@@ -3478,8 +3522,19 @@ checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.6",
- "secp256k1-sys",
+ "secp256k1-sys 0.10.1",
  "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.9.4",
+ "secp256k1-sys 0.11.0",
 ]
 
 [[package]]
@@ -3492,12 +3547,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3540,9 +3604,9 @@ dependencies = [
 
 [[package]]
 name = "send_wrapper"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -3580,14 +3644,14 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3605,15 +3669,6 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -3681,19 +3736,19 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
- "digest 0.10.7",
+ "digest 0.11.3",
  "keccak",
 ]
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cbb88c189d6352cc8ae96a39d19c7ecad8f7330b29461187f2587fdc2988d5"
+checksum = "a6287fd675f713484342a89cbf0a386abef5f15919cfad607e5e1f19e1e15331"
 dependencies = [
  "cc",
  "cfg-if",
@@ -3710,9 +3765,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -3752,8 +3807,8 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "sizzle-parser"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -3782,15 +3837,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3830,11 +3885,11 @@ dependencies = [
 
 [[package]]
 name = "ssz"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
  "hex",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "smallvec",
  "ssz_primitives",
@@ -3843,8 +3898,8 @@ dependencies = [
 
 [[package]]
 name = "ssz_codegen"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -3855,26 +3910,26 @@ dependencies = [
  "ssz_derive",
  "ssz_primitives",
  "ssz_types",
- "syn 2.0.117",
- "toml 0.8.23",
+ "syn 2.0.118",
+ "toml",
  "tree_hash",
  "tree_hash_derive",
 ]
 
 [[package]]
 name = "ssz_derive"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
  "darling",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "ssz_primitives"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
  "hex",
  "rand 0.8.6",
@@ -3883,10 +3938,10 @@ dependencies = [
 
 [[package]]
 name = "ssz_types"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_derive",
  "ssz",
@@ -3931,7 +3986,7 @@ dependencies = [
  "strata-tasks",
  "thiserror 1.0.69",
  "tokio",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "tracing",
  "typed-sled",
 ]
@@ -3942,7 +3997,7 @@ version = "0.2.0"
 dependencies = [
  "serde",
  "status-utils",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "tracing",
 ]
 
@@ -3976,7 +4031,7 @@ dependencies = [
  "status-utils",
  "strata-tasks",
  "tokio",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "tracing",
 ]
 
@@ -3998,7 +4053,7 @@ checksum = "4af28eeb7c18ac2dbdb255d40bee63f203120e1db6b0024b177746ebec7049c1"
 [[package]]
 name = "strata-asm-common"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "bitcoin",
  "borsh",
@@ -4025,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-manifest-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "borsh",
  "serde",
@@ -4046,15 +4101,16 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "bitcoin",
- "bitcoin-bosd 0.10.0",
+ "bitcoin-bosd 0.11.0",
  "strata-asm-common",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95)",
  "strata-btc-types",
  "strata-codec",
+ "strata-crypto",
  "strata-l1-txfmt",
  "thiserror 2.0.18",
 ]
@@ -4062,10 +4118,10 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
- "bitcoin-bosd 0.10.0",
+ "bitcoin-bosd 0.11.0",
  "bitvec",
  "borsh",
  "serde",
@@ -4079,10 +4135,10 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
- "bitcoin-bosd 0.10.0",
+ "bitcoin-bosd 0.11.0",
  "bitvec",
  "borsh",
  "serde",
@@ -4096,10 +4152,10 @@ dependencies = [
 [[package]]
 name = "strata-bridge-connectors"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=0ecec67b67db89f6b761ffeaa09af8e7ad864bb1#0ecec67b67db89f6b761ffeaa09af8e7ad864bb1"
+source = "git+https://github.com/alpenlabs/strata-bridge.git?tag=v0.3.0-rc.1#089ed5d25cc54c31b0c53df6807c7a2cfb48bc38"
 dependencies = [
  "bitcoin",
- "secp256k1",
+ "secp256k1 0.29.1",
  "serde",
  "strata-bridge-primitives",
  "strata-crypto",
@@ -4108,12 +4164,12 @@ dependencies = [
 [[package]]
 name = "strata-bridge-p2p-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=0ecec67b67db89f6b761ffeaa09af8e7ad864bb1#0ecec67b67db89f6b761ffeaa09af8e7ad864bb1"
+source = "git+https://github.com/alpenlabs/strata-bridge.git?tag=v0.3.0-rc.1#089ed5d25cc54c31b0c53df6807c7a2cfb48bc38"
 dependencies = [
  "bitcoin",
- "bitcoin-bosd 0.10.0",
+ "bitcoin-bosd 0.11.0",
  "libp2p-identity",
- "musig2 0.1.1 (git+https://github.com/alpenlabs/musig2?branch=fix%2Fdeserialization-mismatch)",
+ "musig2 0.1.1",
  "proptest",
  "proptest-derive",
  "rkyv",
@@ -4124,55 +4180,54 @@ dependencies = [
 [[package]]
 name = "strata-bridge-primitives"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=0ecec67b67db89f6b761ffeaa09af8e7ad864bb1#0ecec67b67db89f6b761ffeaa09af8e7ad864bb1"
+source = "git+https://github.com/alpenlabs/strata-bridge.git?tag=v0.3.0-rc.1#089ed5d25cc54c31b0c53df6807c7a2cfb48bc38"
 dependencies = [
  "algebra",
  "anyhow",
  "arbitrary",
  "bitcoin",
- "bitcoin-bosd 0.10.0",
+ "bitcoin-bosd 0.11.0",
  "bitcoin-script",
  "futures",
  "hex",
  "libp2p-identity",
  "miniscript",
- "musig2 0.1.1 (git+https://github.com/alpenlabs/musig2?branch=fix%2Fdeserialization-mismatch)",
+ "musig2 0.1.1",
  "proptest",
  "proptest-derive",
  "rkyv",
- "secp256k1",
+ "secp256k1 0.29.1",
  "serde",
  "strata-crypto",
  "strata-identifiers",
  "strata-predicate",
  "thiserror 2.0.18",
  "tokio",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido",
 ]
 
 [[package]]
 name = "strata-bridge-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=0ecec67b67db89f6b761ffeaa09af8e7ad864bb1#0ecec67b67db89f6b761ffeaa09af8e7ad864bb1"
+source = "git+https://github.com/alpenlabs/strata-bridge.git?tag=v0.3.0-rc.1#089ed5d25cc54c31b0c53df6807c7a2cfb48bc38"
 dependencies = [
  "bitcoin",
  "jsonrpsee",
- "secp256k1",
+ "secp256k1 0.29.1",
  "serde",
  "strata-bridge-primitives",
  "strata-bridge-sm",
  "strata-bridge-tx-graph",
- "strata-identifiers",
 ]
 
 [[package]]
 name = "strata-bridge-sm"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=0ecec67b67db89f6b761ffeaa09af8e7ad864bb1#0ecec67b67db89f6b761ffeaa09af8e7ad864bb1"
+source = "git+https://github.com/alpenlabs/strata-bridge.git?tag=v0.3.0-rc.1#089ed5d25cc54c31b0c53df6807c7a2cfb48bc38"
 dependencies = [
  "bitcoin",
- "bitcoin-bosd 0.10.0",
- "musig2 0.1.1 (git+https://github.com/alpenlabs/musig2?branch=fix%2Fdeserialization-mismatch)",
+ "bitcoin-bosd 0.11.0",
+ "musig2 0.1.1",
  "serde",
  "serde-big-array",
  "strata-asm-common",
@@ -4186,19 +4241,19 @@ dependencies = [
  "strata-predicate",
  "thiserror 2.0.18",
  "tracing",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido",
 ]
 
 [[package]]
 name = "strata-bridge-tx-graph"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=0ecec67b67db89f6b761ffeaa09af8e7ad864bb1#0ecec67b67db89f6b761ffeaa09af8e7ad864bb1"
+source = "git+https://github.com/alpenlabs/strata-bridge.git?tag=v0.3.0-rc.1#089ed5d25cc54c31b0c53df6807c7a2cfb48bc38"
 dependencies = [
  "algebra",
  "bitcoin",
- "bitcoin-bosd 0.10.0",
+ "bitcoin-bosd 0.11.0",
  "futures",
- "secp256k1",
+ "secp256k1 0.29.1",
  "serde",
  "strata-asm-proto-bridge-v1-txs",
  "strata-bridge-connectors",
@@ -4210,27 +4265,29 @@ dependencies = [
 [[package]]
 name = "strata-btc-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#36468e192a3dad031fa962f7f6539df5f49abe7d"
 dependencies = [
  "arbitrary",
  "bitcoin",
  "bitcoin-bosd 0.9.0",
  "borsh",
- "num_enum",
  "serde",
  "ssz",
+ "ssz_codegen",
  "ssz_derive",
+ "ssz_primitives",
+ "ssz_types",
  "strata-codec",
  "strata-identifiers",
- "strata-l1-txfmt",
  "thiserror 2.0.18",
  "tree_hash",
+ "tree_hash_derive",
 ]
 
 [[package]]
 name = "strata-btc-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -4247,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "strata-codec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#36468e192a3dad031fa962f7f6539df5f49abe7d"
 dependencies = [
  "strata-codec-derive",
  "thiserror 2.0.18",
@@ -4256,36 +4313,41 @@ dependencies = [
 [[package]]
 name = "strata-codec-derive"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#36468e192a3dad031fa962f7f6539df5f49abe7d"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "strata-crypto"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#36468e192a3dad031fa962f7f6539df5f49abe7d"
 dependencies = [
  "arbitrary",
  "bitcoin",
  "borsh",
  "hex",
- "musig2 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "secp256k1",
+ "musig2 0.1.2",
+ "secp256k1 0.29.1",
  "serde",
  "sha2",
  "ssz",
+ "ssz_codegen",
  "ssz_derive",
+ "ssz_primitives",
+ "ssz_types",
  "strata-identifiers",
  "thiserror 2.0.18",
+ "tree_hash",
+ "tree_hash_derive",
  "zeroize",
 ]
 
 [[package]]
 name = "strata-identifiers"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#36468e192a3dad031fa962f7f6539df5f49abe7d"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -4306,7 +4368,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-txfmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#36468e192a3dad031fa962f7f6539df5f49abe7d"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -4318,7 +4380,7 @@ dependencies = [
 [[package]]
 name = "strata-merkle"
 version = "0.2.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#36468e192a3dad031fa962f7f6539df5f49abe7d"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -4338,7 +4400,7 @@ dependencies = [
 [[package]]
 name = "strata-mosaic-client-api"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-bridge.git?rev=0ecec67b67db89f6b761ffeaa09af8e7ad864bb1#0ecec67b67db89f6b761ffeaa09af8e7ad864bb1"
+source = "git+https://github.com/alpenlabs/strata-bridge.git?tag=v0.3.0-rc.1#089ed5d25cc54c31b0c53df6807c7a2cfb48bc38"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -4350,7 +4412,7 @@ dependencies = [
 [[package]]
 name = "strata-msg-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#36468e192a3dad031fa962f7f6539df5f49abe7d"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -4358,14 +4420,14 @@ dependencies = [
 [[package]]
 name = "strata-ol-bridge-types"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/alpen.git?rev=2c6ae209dd5f2ed71e6f9f7b721ea7ab21190e10#2c6ae209dd5f2ed71e6f9f7b721ea7ab21190e10"
+source = "git+https://github.com/alpenlabs/alpen.git?tag=v0.3.0-rc.1#e63783002c12b5e61891cf1b04c341cbf0f31bd3"
 dependencies = [
  "arbitrary",
  "borsh",
  "serde",
  "ssz",
  "ssz_derive",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1)",
  "strata-codec",
  "strata-identifiers",
  "strata-primitives",
@@ -4375,7 +4437,7 @@ dependencies = [
 [[package]]
 name = "strata-predicate"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#36468e192a3dad031fa962f7f6539df5f49abe7d"
 dependencies = [
  "borsh",
  "hex",
@@ -4396,10 +4458,10 @@ dependencies = [
 [[package]]
 name = "strata-primitives"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/alpen.git?rev=2c6ae209dd5f2ed71e6f9f7b721ea7ab21190e10#2c6ae209dd5f2ed71e6f9f7b721ea7ab21190e10"
+source = "git+https://github.com/alpenlabs/alpen.git?tag=v0.3.0-rc.1#e63783002c12b5e61891cf1b04c341cbf0f31bd3"
 dependencies = [
  "bitcoin",
- "bitcoin-bosd 0.10.0",
+ "bitcoin-bosd 0.11.0",
  "borsh",
  "hex",
  "serde",
@@ -4412,7 +4474,7 @@ dependencies = [
 [[package]]
 name = "strata-tasks"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc16#a0c346696ffbf2bc95b7fa37174e09d41462efa3"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#36468e192a3dad031fa962f7f6539df5f49abe7d"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -4459,9 +4521,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4470,14 +4532,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f425ae0b12e2f5ae65542e00898d500d4d318b4baf09f40fd0d410454e9947"
+checksum = "ec005042c7d952febc1a3ef5b0f6674e9054aa836877a31c90b20e25b3d31744"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4497,7 +4559,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4506,7 +4568,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4534,7 +4596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4566,7 +4628,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4577,7 +4639,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4616,9 +4678,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4639,7 +4701,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4680,38 +4742,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "serde_spanned",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
+ "winnow",
 ]
 
 [[package]]
@@ -4725,28 +4766,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
-dependencies = [
- "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
@@ -4755,14 +4782,8 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -4788,20 +4809,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -4836,7 +4857,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4880,8 +4901,8 @@ dependencies = [
 
 [[package]]
 name = "tree_hash"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
  "digest 0.10.7",
  "sha2",
@@ -4893,12 +4914,12 @@ dependencies = [
 
 [[package]]
 name = "tree_hash_derive"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
  "darling",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4910,19 +4931,19 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "typed-sled"
 version = "0.1.1"
-source = "git+https://github.com/alpenlabs/typed-sled#91ec668184350b8121625942c03152aade330b4b"
+source = "git+https://github.com/alpenlabs/typed-sled#ca4f6efc36fc63d80ba8691cb0e2ca775a80eb8a"
 dependencies = [
  "dashmap",
  "rkyv",
  "sled",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -4956,9 +4977,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"
@@ -4992,9 +5013,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5048,27 +5069,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5079,9 +5091,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5089,9 +5101,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5099,65 +5111,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap",
- "semver 1.0.28",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5179,14 +5157,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.7",
+ "webpki-root-certs 1.0.8",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5286,6 +5264,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5317,11 +5304,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5337,6 +5341,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5347,6 +5357,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5361,10 +5377,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5379,6 +5407,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5389,6 +5423,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5403,6 +5443,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5415,30 +5461,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.15"
+name = "windows_x86_64_msvc"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
 ]
 
 [[package]]
@@ -5446,85 +5480,6 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver 1.0.28",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -5543,9 +5498,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5560,35 +5515,35 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -5601,28 +5556,28 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5655,35 +5610,24 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "zkaleido"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.1#d24c4ce44e4ff2abd4328a5adb373ffb79f34c8c"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.3.0-rc.1#b1c3a5a34ea713d6e35e792c497d4f8327feaf61"
 dependencies = [
  "bincode",
  "borsh",
  "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "zkaleido"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2#c2683cf676490decc045d9a91d6c8b5740138f1c"
-dependencies = [
- "bincode",
- "borsh",
- "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "zkaleido-logging"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2#c2683cf676490decc045d9a91d6c8b5740138f1c"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.3.0-rc.1#b1c3a5a34ea713d6e35e792c497d4f8327feaf61"
 dependencies = [
  "tracing",
 ]
@@ -5691,7 +5635,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-sp1-groth16-verifier"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.1#d24c4ce44e4ff2abd4328a5adb373ffb79f34c8c"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.3.0-rc.1#b1c3a5a34ea713d6e35e792c497d4f8327feaf61"
 dependencies = [
  "blake3",
  "borsh",
@@ -5699,8 +5643,8 @@ dependencies = [
  "serde",
  "sha2",
  "substrate-bn",
- "thiserror 1.0.69",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.1)",
+ "thiserror 2.0.18",
+ "zkaleido",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -19,15 +19,13 @@
     status-network = { path = "crates/network" }
     status-utils   = { path = "crates/utils" }
 
-    # alpen pinned to the rev referenced by the chosen strata-bridge revision,
-    # so the transitive `strata-primitives`/`Buf32` matches our direct pin.
-    alpen-reth-primitives = { git = "https://github.com/alpenlabs/alpen.git", rev = "2c6ae209dd5f2ed71e6f9f7b721ea7ab21190e10" }
-    strata-bridge-primitives = { git = "https://github.com/alpenlabs/strata-bridge.git", rev = "0ecec67b67db89f6b761ffeaa09af8e7ad864bb1" }
+    alpen-reth-primitives = { git = "https://github.com/alpenlabs/alpen.git", tag = "v0.3.0-rc.1" }
+    strata-bridge-primitives = { git = "https://github.com/alpenlabs/strata-bridge.git", tag = "v0.3.0-rc.1" }
     strata-bridge-rpc = { git = "https://github.com/alpenlabs/strata-bridge.git", features = [
       "client",
-    ], rev = "0ecec67b67db89f6b761ffeaa09af8e7ad864bb1" }
-    strata-primitives = { git = "https://github.com/alpenlabs/alpen.git", rev = "2c6ae209dd5f2ed71e6f9f7b721ea7ab21190e10" }
-    strata-tasks = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc16" }
+    ], tag = "v0.3.0-rc.1" }
+    strata-primitives = { git = "https://github.com/alpenlabs/alpen.git", tag = "v0.3.0-rc.1" }
+    strata-tasks = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0-rc.1" }
     typed-sled = { git = "https://github.com/alpenlabs/typed-sled" }
 
     # External

--- a/backend/crates/bridge/src/cache.rs
+++ b/backend/crates/bridge/src/cache.rs
@@ -2,9 +2,12 @@ use std::collections::{BTreeMap, HashMap};
 use std::time::{SystemTime, UNIX_EPOCH};
 use strata_bridge_primitives::types::DepositIdx;
 
-use super::types::{
-    DepositInfo, OperatorStatus, ReimbursementInfo, ReimbursementStatusCursor, WithdrawalInfo,
-    WithdrawalPairingCursor, WithdrawalSeq, WithdrawalStatusCursor,
+use super::{
+    db::types::DbBridgeStatusSnapshot,
+    types::{
+        DepositInfo, OperatorStatus, ReimbursementInfo, ReimbursementStatusCursor, WithdrawalInfo,
+        WithdrawalPairing, WithdrawalPairingCursor, WithdrawalSeq, WithdrawalStatusCursor,
+    },
 };
 
 /// Cache entry with timestamp and confirmation tracking
@@ -40,7 +43,7 @@ impl<T> CacheEntry<T> {
 
 /// In-memory withdrawal-to-deposit pairings and their FIFO cursor.
 #[derive(Debug, Default, Clone)]
-pub(crate) struct WithdrawalPairing {
+pub(crate) struct WithdrawalPairingState {
     pairings: BTreeMap<DepositIdx, WithdrawalSeq>,
     cursor: WithdrawalPairingCursor,
 }
@@ -50,7 +53,7 @@ pub(crate) struct WithdrawalPairing {
 pub(crate) struct BridgeStatusCache {
     deposits: HashMap<DepositIdx, CacheEntry<DepositInfo>>,
     deposit_info_cursor: DepositIdx,
-    withdrawal_pairing: WithdrawalPairing,
+    withdrawal_pairing: WithdrawalPairingState,
     withdrawal_status_cursor: WithdrawalStatusCursor,
     withdrawals: HashMap<DepositIdx, CacheEntry<WithdrawalInfo>>,
     reimbursement_status_cursor: ReimbursementStatusCursor,
@@ -59,6 +62,27 @@ pub(crate) struct BridgeStatusCache {
 }
 
 impl BridgeStatusCache {
+    pub(crate) fn from_status_snapshot(snapshot: DbBridgeStatusSnapshot) -> Self {
+        let mut cache = Self::default();
+
+        cache.apply_withdrawal_updates(
+            snapshot
+                .withdrawals
+                .into_iter()
+                .map(|(deposit_idx, info)| (deposit_idx, info, None))
+                .collect(),
+        );
+        cache.update_withdrawal_pairings(
+            &snapshot.withdrawal_pairings,
+            snapshot.cursors.withdrawal_pairing,
+        );
+        cache.set_deposit_info_cursor(snapshot.cursors.deposit_info);
+        cache.set_withdrawal_status_cursor(snapshot.cursors.withdrawal_status);
+        cache.set_reimbursement_status_cursor(snapshot.cursors.reimbursement_status);
+
+        cache
+    }
+
     pub(crate) fn deposit_info_cursor(&self) -> DepositIdx {
         self.deposit_info_cursor
     }
@@ -74,22 +98,26 @@ impl BridgeStatusCache {
     pub(crate) fn withdrawal_pairings_from(
         &self,
         deposit_idx: DepositIdx,
-    ) -> Vec<(DepositIdx, WithdrawalSeq)> {
+    ) -> Vec<WithdrawalPairing> {
         self.withdrawal_pairing
             .pairings
             .range(deposit_idx..)
-            .map(|(deposit_idx, withdrawal_seq)| (*deposit_idx, *withdrawal_seq))
+            .map(|(deposit_idx, withdrawal_seq)| {
+                WithdrawalPairing::new(*deposit_idx, *withdrawal_seq)
+            })
             .collect()
     }
 
     pub(crate) fn update_withdrawal_pairings(
         &mut self,
-        pairings: &[(DepositIdx, WithdrawalSeq)],
+        pairings: &[WithdrawalPairing],
         cursor: WithdrawalPairingCursor,
     ) {
-        self.withdrawal_pairing
-            .pairings
-            .extend(pairings.iter().copied());
+        self.withdrawal_pairing.pairings.extend(
+            pairings
+                .iter()
+                .map(|pairing| (pairing.deposit_idx, pairing.withdrawal_seq)),
+        );
         self.withdrawal_pairing.cursor = cursor;
     }
 

--- a/backend/crates/bridge/src/db/status/db.rs
+++ b/backend/crates/bridge/src/db/status/db.rs
@@ -11,7 +11,7 @@ use crate::{
         types::{DbBridgeStatusSnapshot, StatusCursors},
     },
     types::{
-        ReimbursementStatusCursor, WithdrawalInfo, WithdrawalPairingCursor, WithdrawalSeq,
+        ReimbursementStatusCursor, WithdrawalInfo, WithdrawalPairing, WithdrawalPairingCursor,
         WithdrawalStatusCursor,
     },
 };
@@ -108,6 +108,12 @@ impl BridgeStatusDb for BridgeStatusDbSled {
                 .withdrawal_pairings
                 .iter()
                 .map(|result| result.map_err(DbError::from))
+                .map(|result| {
+                    result.map(|(deposit_idx, withdrawal_seq)| WithdrawalPairing {
+                        deposit_idx,
+                        withdrawal_seq,
+                    })
+                })
                 .collect::<DbResult<_>>()?,
             cursors: self.status_cursors()?,
         })
@@ -122,10 +128,10 @@ impl BridgeStatusDb for BridgeStatusDbSled {
         Ok(self.withdrawals.take(&deposit_idx)?.is_some())
     }
 
-    fn put_withdrawal_pairings(&self, pairings: &[(DepositIdx, WithdrawalSeq)]) -> DbResult<()> {
-        for (deposit_idx, withdrawal_seq) in pairings {
+    fn put_withdrawal_pairings(&self, pairings: &[WithdrawalPairing]) -> DbResult<()> {
+        for pairing in pairings {
             self.withdrawal_pairings
-                .insert(deposit_idx, withdrawal_seq)?;
+                .insert(&pairing.deposit_idx, &pairing.withdrawal_seq)?;
         }
         Ok(())
     }
@@ -188,7 +194,7 @@ mod tests {
     use super::*;
     use crate::{
         db::status::mock::MockBridgeStatusDb,
-        types::{WithdrawalInfo, WithdrawalStatus},
+        types::{WithdrawalInfo, WithdrawalPairing, WithdrawalStatus},
     };
 
     fn txid(byte: u8) -> Txid {
@@ -213,6 +219,13 @@ mod tests {
             fulfillment_txid: Some(txid(byte + 1)),
             status,
         }
+    }
+
+    fn pairing(
+        deposit_idx: DepositIdx,
+        withdrawal_seq: crate::types::WithdrawalSeq,
+    ) -> WithdrawalPairing {
+        WithdrawalPairing::new(deposit_idx, withdrawal_seq)
     }
 
     fn assert_empty_snapshot(db: &impl BridgeStatusDb) {
@@ -240,7 +253,7 @@ mod tests {
 
         db.put_withdrawal_info(2, &withdrawal)
             .expect("put withdrawal");
-        db.put_withdrawal_pairings(&[(1, 7), (2, 8)])
+        db.put_withdrawal_pairings(&[pairing(1, 7), pairing(2, 8)])
             .expect("put pairings");
         db.put_deposit_info_cursor(cursors.deposit_info)
             .expect("put deposit cursor");
@@ -258,7 +271,10 @@ mod tests {
             snapshot.withdrawals[0].1.withdrawal_request_txid,
             Buf32([3; 32])
         );
-        assert_eq!(snapshot.withdrawal_pairings, vec![(1, 7), (2, 8)]);
+        assert_eq!(
+            snapshot.withdrawal_pairings,
+            vec![pairing(1, 7), pairing(2, 8)]
+        );
         assert_eq!(snapshot.cursors, cursors);
 
         db.del_withdrawal_pairings_range(0, 2)
@@ -268,13 +284,18 @@ mod tests {
 
         let snapshot = db.get_status_snapshot().expect("snapshot after deletes");
         assert!(snapshot.withdrawals.is_empty());
-        assert_eq!(snapshot.withdrawal_pairings, vec![(2, 8)]);
+        assert_eq!(snapshot.withdrawal_pairings, vec![pairing(2, 8)]);
         assert_eq!(snapshot.cursors, cursors);
     }
 
     fn assert_pairing_range_delete(db: &impl BridgeStatusDb) {
-        db.put_withdrawal_pairings(&[(1, 10), (2, 20), (4, 40), (5, 50)])
-            .expect("put pairings");
+        db.put_withdrawal_pairings(&[
+            pairing(1, 10),
+            pairing(2, 20),
+            pairing(4, 40),
+            pairing(5, 50),
+        ])
+        .expect("put pairings");
 
         db.del_withdrawal_pairings_range(2, 5)
             .expect("delete middle range");
@@ -282,7 +303,7 @@ mod tests {
             db.get_status_snapshot()
                 .expect("snapshot")
                 .withdrawal_pairings,
-            vec![(1, 10), (5, 50)]
+            vec![pairing(1, 10), pairing(5, 50)]
         );
 
         db.del_withdrawal_pairings_range(5, 5)
@@ -293,7 +314,7 @@ mod tests {
             db.get_status_snapshot()
                 .expect("snapshot")
                 .withdrawal_pairings,
-            vec![(1, 10), (5, 50)]
+            vec![pairing(1, 10), pairing(5, 50)]
         );
     }
 

--- a/backend/crates/bridge/src/db/status/mock.rs
+++ b/backend/crates/bridge/src/db/status/mock.rs
@@ -10,8 +10,8 @@ use crate::{
         types::{DbBridgeStatusSnapshot, StatusCursors},
     },
     types::{
-        ReimbursementStatusCursor, WithdrawalInfo, WithdrawalPairingCursor, WithdrawalSeq,
-        WithdrawalStatusCursor,
+        ReimbursementStatusCursor, WithdrawalInfo, WithdrawalPairing, WithdrawalPairingCursor,
+        WithdrawalSeq, WithdrawalStatusCursor,
     },
 };
 
@@ -41,7 +41,9 @@ impl BridgeStatusDb for MockBridgeStatusDb {
                 .read()
                 .expect("mock withdrawal_pairings lock poisoned")
                 .iter()
-                .map(|(deposit_idx, withdrawal_seq)| (*deposit_idx, *withdrawal_seq))
+                .map(|(deposit_idx, withdrawal_seq)| {
+                    WithdrawalPairing::new(*deposit_idx, *withdrawal_seq)
+                })
                 .collect(),
             cursors: StatusCursors {
                 deposit_info: *self
@@ -81,11 +83,15 @@ impl BridgeStatusDb for MockBridgeStatusDb {
             .is_some())
     }
 
-    fn put_withdrawal_pairings(&self, pairings: &[(DepositIdx, WithdrawalSeq)]) -> DbResult<()> {
+    fn put_withdrawal_pairings(&self, pairings: &[WithdrawalPairing]) -> DbResult<()> {
         self.withdrawal_pairings
             .write()
             .expect("mock withdrawal_pairings lock poisoned")
-            .extend(pairings.iter().copied());
+            .extend(
+                pairings
+                    .iter()
+                    .map(|pairing| (pairing.deposit_idx, pairing.withdrawal_seq)),
+            );
         Ok(())
     }
 

--- a/backend/crates/bridge/src/db/traits.rs
+++ b/backend/crates/bridge/src/db/traits.rs
@@ -9,7 +9,7 @@ use crate::{
         },
     },
     types::{
-        ReimbursementStatusCursor, WithdrawalInfo, WithdrawalPairingCursor, WithdrawalSeq,
+        ReimbursementStatusCursor, WithdrawalInfo, WithdrawalPairing, WithdrawalPairingCursor,
         WithdrawalStatusCursor,
     },
 };
@@ -60,7 +60,7 @@ pub(crate) trait BridgeStatusDb: Send + Sync {
     fn del_withdrawal_info(&self, deposit_idx: DepositIdx) -> DbResult<bool>;
 
     /// Inserts or replaces withdrawal-to-deposit pairings.
-    fn put_withdrawal_pairings(&self, pairings: &[(DepositIdx, WithdrawalSeq)]) -> DbResult<()>;
+    fn put_withdrawal_pairings(&self, pairings: &[WithdrawalPairing]) -> DbResult<()>;
 
     /// Deletes withdrawal-to-deposit pairing rows in `start..end`.
     fn del_withdrawal_pairings_range(&self, start: DepositIdx, end: DepositIdx) -> DbResult<()>;

--- a/backend/crates/bridge/src/db/types.rs
+++ b/backend/crates/bridge/src/db/types.rs
@@ -5,7 +5,7 @@ use strata_bridge_primitives::types::DepositIdx;
 use strata_primitives::buf::Buf32;
 
 use crate::types::{
-    ReimbursementStatusCursor, WithdrawalInfo, WithdrawalPairingCursor, WithdrawalSeq,
+    ReimbursementStatusCursor, WithdrawalInfo, WithdrawalPairing, WithdrawalPairingCursor,
     WithdrawalStatusCursor,
 };
 
@@ -22,7 +22,7 @@ pub(crate) struct StatusCursors {
 #[derive(Debug, Clone)]
 pub(crate) struct DbBridgeStatusSnapshot {
     pub(crate) withdrawals: Vec<(DepositIdx, WithdrawalInfo)>,
-    pub(crate) withdrawal_pairings: Vec<(DepositIdx, WithdrawalSeq)>,
+    pub(crate) withdrawal_pairings: Vec<WithdrawalPairing>,
     pub(crate) cursors: StatusCursors,
 }
 

--- a/backend/crates/bridge/src/state.rs
+++ b/backend/crates/bridge/src/state.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use strata_bridge_primitives::types::DepositIdx;
 use tokio::sync::RwLock;
@@ -13,8 +13,8 @@ use super::{
     },
     types::{
         BridgeStatus, DepositInfo, DepositStatus, OperatorStatus, ReimbursementInfo,
-        ReimbursementStatus, ReimbursementStatusCursor, WithdrawalInfo, WithdrawalPairingCursor,
-        WithdrawalSeq, WithdrawalStatus, WithdrawalStatusCursor,
+        ReimbursementStatus, ReimbursementStatusCursor, WithdrawalInfo, WithdrawalPairing,
+        WithdrawalPairingCursor, WithdrawalSeq, WithdrawalStatus, WithdrawalStatusCursor,
     },
 };
 
@@ -27,13 +27,6 @@ pub(crate) struct DepositInfoUpdate {
     pub(crate) deposit_idx: DepositIdx,
     pub(crate) info: DepositInfo,
     pub(crate) confirmations: Option<u64>,
-}
-
-/// Paired withdrawal candidate whose bridge status can be queried.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct WithdrawalStatusCandidate {
-    pub(crate) deposit_idx: DepositIdx,
-    pub(crate) withdrawal_seq: WithdrawalSeq,
 }
 
 /// Withdrawal status update collected during one monitoring tick.
@@ -52,6 +45,12 @@ pub(crate) struct ReimbursementInfoUpdate {
     pub(crate) confirmations: Option<u64>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WithdrawalPairingUpdate {
+    pairings: Vec<WithdrawalPairing>,
+    cursor: WithdrawalPairingCursor,
+}
+
 /// Mutable bridge monitoring state shared by the polling task and HTTP handler.
 #[derive(Debug, Default)]
 pub(crate) struct BridgeMonitoringState {
@@ -61,7 +60,7 @@ pub(crate) struct BridgeMonitoringState {
 impl BridgeMonitoringState {
     pub(crate) fn from_snapshot(snapshot: DbBridgeStatusSnapshot) -> Self {
         Self {
-            cache: RwLock::new(cache_from_status_snapshot(snapshot)),
+            cache: RwLock::new(BridgeStatusCache::from_status_snapshot(snapshot)),
         }
     }
 
@@ -126,12 +125,13 @@ impl BridgeMonitoringState {
         cache.withdrawal_pairing_cursor()
     }
 
-    pub(crate) async fn apply_withdrawal_pairings(
+    pub(crate) async fn advance_withdrawal_pairings(
         &self,
         status_db: &impl BridgeStatusDb,
         deposit_indices: &[DepositIdx],
+        deposit_infos: &[(DepositIdx, DepositInfo)],
         withdrawal_requests: &[DbWithdrawalRequestRow],
-    ) -> DbResult<Vec<(DepositIdx, WithdrawalSeq)>> {
+    ) -> DbResult<Vec<WithdrawalPairing>> {
         let withdrawal_seqs = withdrawal_requests
             .iter()
             .map(|row| row.seq)
@@ -140,33 +140,32 @@ impl BridgeMonitoringState {
             let cache = self.cache.read().await;
             cache.withdrawal_pairing_cursor()
         };
-        let (pairings, next_cursor) =
-            plan_withdrawal_pairings(current_cursor, deposit_indices, &withdrawal_seqs);
-        if pairings.is_empty() {
-            return Ok(pairings);
+        let update = plan_withdrawal_pairings(
+            current_cursor,
+            deposit_indices,
+            deposit_infos,
+            &withdrawal_seqs,
+        );
+        if update.pairings.is_empty() && update.cursor == current_cursor {
+            return Ok(update.pairings);
         }
 
-        status_db.put_withdrawal_pairings(&pairings)?;
-        status_db.put_withdrawal_pairing_cursor(next_cursor)?;
+        if !update.pairings.is_empty() {
+            status_db.put_withdrawal_pairings(&update.pairings)?;
+        }
+        if update.cursor != current_cursor {
+            status_db.put_withdrawal_pairing_cursor(update.cursor)?;
+        }
 
         let mut cache = self.cache.write().await;
-        cache.update_withdrawal_pairings(&pairings, next_cursor);
-        Ok(pairings)
+        cache.update_withdrawal_pairings(&update.pairings, update.cursor);
+        Ok(update.pairings)
     }
 
-    pub(crate) async fn select_withdrawal_status_candidates(
-        &self,
-    ) -> Vec<WithdrawalStatusCandidate> {
+    pub(crate) async fn select_withdrawal_status_candidates(&self) -> Vec<WithdrawalPairing> {
         let cache = self.cache.read().await;
         let cursor = cache.withdrawal_status_cursor().next_deposit_idx;
-        cache
-            .withdrawal_pairings_from(cursor)
-            .into_iter()
-            .map(|(deposit_idx, withdrawal_seq)| WithdrawalStatusCandidate {
-                deposit_idx,
-                withdrawal_seq,
-            })
-            .collect()
+        cache.withdrawal_pairings_from(cursor)
     }
 
     pub(crate) async fn update_operators(&self, operators: Vec<OperatorStatus>) {
@@ -203,12 +202,25 @@ impl BridgeMonitoringState {
             }
         }
 
-        let current_cursor = {
+        let (current_cursor, pairing_frontier, paired_deposit_indices) = {
             let cache = self.cache.read().await;
-            cache.withdrawal_status_cursor()
+            let current_cursor = cache.withdrawal_status_cursor();
+            (
+                current_cursor,
+                cache.withdrawal_pairing_cursor().next_deposit_idx,
+                cache
+                    .withdrawal_pairings_from(current_cursor.next_deposit_idx)
+                    .into_iter()
+                    .map(|pairing| pairing.deposit_idx)
+                    .collect::<Vec<_>>(),
+            )
         };
-        let next_cursor =
-            next_withdrawal_status_cursor(current_cursor, &terminal_deposit_indices_to_purge);
+        let next_cursor = next_withdrawal_status_cursor(
+            current_cursor,
+            &terminal_deposit_indices_to_purge,
+            pairing_frontier,
+            &paired_deposit_indices,
+        );
         for (deposit_idx, info) in &withdrawal_infos_to_persist {
             status_db.put_withdrawal_info(*deposit_idx, info)?;
         }
@@ -236,20 +248,14 @@ impl BridgeMonitoringState {
     pub(crate) async fn select_reimbursement_status_candidates(&self) -> Vec<DepositIdx> {
         let cache = self.cache.read().await;
         let reimbursement_cursor = cache.reimbursement_status_cursor().next_deposit_idx;
-        let withdrawal_cursor = cache.withdrawal_status_cursor().next_deposit_idx;
-        let mut candidates = (reimbursement_cursor..withdrawal_cursor).collect::<BTreeSet<_>>();
-
-        candidates.extend(
-            cache
-                .filter_withdrawals(|deposit_idx, info, _| {
-                    deposit_idx >= reimbursement_cursor
-                        && matches!(info.status, WithdrawalStatus::Complete)
-                })
-                .into_iter()
-                .map(|(deposit_idx, _)| deposit_idx),
-        );
-
-        candidates.into_iter().collect()
+        cache
+            .filter_withdrawals(|deposit_idx, info, _| {
+                deposit_idx >= reimbursement_cursor
+                    && matches!(info.status, WithdrawalStatus::Complete)
+            })
+            .into_iter()
+            .map(|(deposit_idx, _)| deposit_idx)
+            .collect()
     }
 
     pub(crate) async fn apply_reimbursement_updates(
@@ -286,9 +292,21 @@ impl BridgeMonitoringState {
         let (next_cursor, withdrawal_deposit_indices_to_purge) = {
             let cache = self.cache.read().await;
             let current_cursor = cache.reimbursement_status_cursor();
+            let withdrawal_frontier = cache.withdrawal_status_cursor().next_deposit_idx;
+            let complete_withdrawal_deposit_indices = cache
+                .filter_withdrawals(|deposit_idx, info, _| {
+                    deposit_idx >= current_cursor.next_deposit_idx
+                        && deposit_idx < withdrawal_frontier
+                        && matches!(info.status, WithdrawalStatus::Complete)
+                })
+                .into_iter()
+                .map(|(deposit_idx, _)| deposit_idx)
+                .collect::<Vec<_>>();
             let next_cursor = next_reimbursement_status_cursor(
                 current_cursor,
                 &terminal_deposit_indices_to_purge,
+                withdrawal_frontier,
+                &complete_withdrawal_deposit_indices,
             );
             (
                 next_cursor,
@@ -365,27 +383,6 @@ impl BridgeMonitoringState {
     }
 }
 
-fn cache_from_status_snapshot(snapshot: DbBridgeStatusSnapshot) -> BridgeStatusCache {
-    let mut cache = BridgeStatusCache::default();
-
-    cache.apply_withdrawal_updates(
-        snapshot
-            .withdrawals
-            .into_iter()
-            .map(|(deposit_idx, info)| (deposit_idx, info, None))
-            .collect(),
-    );
-    cache.update_withdrawal_pairings(
-        &snapshot.withdrawal_pairings,
-        snapshot.cursors.withdrawal_pairing,
-    );
-    cache.set_deposit_info_cursor(snapshot.cursors.deposit_info);
-    cache.set_withdrawal_status_cursor(snapshot.cursors.withdrawal_status);
-    cache.set_reimbursement_status_cursor(snapshot.cursors.reimbursement_status);
-
-    cache
-}
-
 fn next_deposit_info_cursor(
     current_cursor: DepositIdx,
     terminal_deposit_indices_to_purge: &[DepositIdx],
@@ -409,56 +406,78 @@ fn next_deposit_info_cursor(
 fn next_withdrawal_status_cursor(
     current_cursor: WithdrawalStatusCursor,
     terminal_deposit_indices_to_purge: &[DepositIdx],
+    pairing_frontier: DepositIdx,
+    paired_deposit_indices: &[DepositIdx],
 ) -> WithdrawalStatusCursor {
-    let terminal_deposit_indices_to_purge = terminal_deposit_indices_to_purge
-        .iter()
-        .copied()
-        .collect::<BTreeSet<_>>();
-    let mut next_cursor = current_cursor.next_deposit_idx;
-
-    while terminal_deposit_indices_to_purge.contains(&next_cursor) {
-        let Some(next) = next_cursor.checked_add(1) else {
-            break;
-        };
-        next_cursor = next;
-    }
-
     WithdrawalStatusCursor {
-        next_deposit_idx: next_cursor,
+        next_deposit_idx: next_sparse_status_cursor(
+            current_cursor.next_deposit_idx,
+            terminal_deposit_indices_to_purge,
+            pairing_frontier,
+            paired_deposit_indices,
+        ),
     }
 }
 
 fn next_reimbursement_status_cursor(
     current_cursor: ReimbursementStatusCursor,
     terminal_deposit_indices_to_purge: &[DepositIdx],
+    withdrawal_frontier: DepositIdx,
+    complete_withdrawal_deposit_indices: &[DepositIdx],
 ) -> ReimbursementStatusCursor {
+    ReimbursementStatusCursor {
+        next_deposit_idx: next_sparse_status_cursor(
+            current_cursor.next_deposit_idx,
+            terminal_deposit_indices_to_purge,
+            withdrawal_frontier,
+            complete_withdrawal_deposit_indices,
+        ),
+    }
+}
+
+fn next_sparse_status_cursor(
+    current_cursor: DepositIdx,
+    terminal_deposit_indices_to_purge: &[DepositIdx],
+    domain_frontier: DepositIdx,
+    pending_domain_indices: &[DepositIdx],
+) -> DepositIdx {
     let terminal_deposit_indices_to_purge = terminal_deposit_indices_to_purge
         .iter()
         .copied()
         .collect::<BTreeSet<_>>();
-    let mut next_cursor = current_cursor.next_deposit_idx;
+    let pending_domain_indices = pending_domain_indices
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let mut next_cursor = current_cursor;
 
-    while terminal_deposit_indices_to_purge.contains(&next_cursor) {
+    while next_cursor < domain_frontier
+        && (terminal_deposit_indices_to_purge.contains(&next_cursor)
+            || !pending_domain_indices.contains(&next_cursor))
+    {
         let Some(next) = next_cursor.checked_add(1) else {
             break;
         };
         next_cursor = next;
     }
 
-    ReimbursementStatusCursor {
-        next_deposit_idx: next_cursor,
-    }
+    next_cursor
 }
 
 fn plan_withdrawal_pairings(
     cursor: WithdrawalPairingCursor,
     discovered_deposit_indices: &[DepositIdx],
+    deposit_infos: &[(DepositIdx, DepositInfo)],
     indexed_withdrawal_seqs: &[WithdrawalSeq],
-) -> (Vec<(DepositIdx, WithdrawalSeq)>, WithdrawalPairingCursor) {
+) -> WithdrawalPairingUpdate {
     let discovered_deposit_indices = discovered_deposit_indices
         .iter()
         .copied()
         .collect::<BTreeSet<_>>();
+    let deposit_infos = deposit_infos
+        .iter()
+        .map(|(deposit_idx, info)| (*deposit_idx, info.status))
+        .collect::<BTreeMap<_, _>>();
     let indexed_withdrawal_seqs = indexed_withdrawal_seqs
         .iter()
         .copied()
@@ -466,27 +485,46 @@ fn plan_withdrawal_pairings(
     let mut next_cursor = cursor;
     let mut pairings = Vec::new();
 
-    while discovered_deposit_indices.contains(&next_cursor.next_deposit_idx)
-        && indexed_withdrawal_seqs.contains(&next_cursor.next_withdrawal_seq)
-    {
-        pairings.push((
-            next_cursor.next_deposit_idx,
-            next_cursor.next_withdrawal_seq,
-        ));
+    while discovered_deposit_indices.contains(&next_cursor.next_deposit_idx) {
+        match deposit_infos.get(&next_cursor.next_deposit_idx) {
+            Some(DepositStatus::Complete) => {
+                if !indexed_withdrawal_seqs.contains(&next_cursor.next_withdrawal_seq) {
+                    break;
+                }
+                pairings.push(WithdrawalPairing::new(
+                    next_cursor.next_deposit_idx,
+                    next_cursor.next_withdrawal_seq,
+                ));
 
-        let Some(next_deposit_idx) = next_cursor.next_deposit_idx.checked_add(1) else {
-            break;
-        };
-        let Some(next_withdrawal_seq) = next_cursor.next_withdrawal_seq.checked_add(1) else {
-            break;
-        };
-        next_cursor = WithdrawalPairingCursor {
-            next_deposit_idx,
-            next_withdrawal_seq,
-        };
+                let Some(next_deposit_idx) = next_cursor.next_deposit_idx.checked_add(1) else {
+                    break;
+                };
+                let Some(next_withdrawal_seq) = next_cursor.next_withdrawal_seq.checked_add(1)
+                else {
+                    break;
+                };
+                next_cursor = WithdrawalPairingCursor {
+                    next_deposit_idx,
+                    next_withdrawal_seq,
+                };
+            }
+            Some(DepositStatus::Failed) => {
+                let Some(next_deposit_idx) = next_cursor.next_deposit_idx.checked_add(1) else {
+                    break;
+                };
+                next_cursor = WithdrawalPairingCursor {
+                    next_deposit_idx,
+                    next_withdrawal_seq: next_cursor.next_withdrawal_seq,
+                };
+            }
+            Some(DepositStatus::InProgress) | None => break,
+        }
     }
 
-    (pairings, next_cursor)
+    WithdrawalPairingUpdate {
+        pairings,
+        cursor: next_cursor,
+    }
 }
 
 #[cfg(test)]
@@ -496,6 +534,26 @@ mod tests {
     use strata_primitives::buf::Buf32;
 
     use crate::db::{traits::BridgeStatusDb, BridgeStatusDbSled};
+
+    fn deposit_info(status: DepositStatus) -> DepositInfo {
+        DepositInfo {
+            deposit_request_txid: Txid::from_byte_array([1; 32]),
+            deposit_txid: matches!(status, DepositStatus::Complete)
+                .then_some(Txid::from_byte_array([2; 32])),
+            status,
+        }
+    }
+
+    fn deposit_infos(statuses: &[(DepositIdx, DepositStatus)]) -> Vec<(DepositIdx, DepositInfo)> {
+        statuses
+            .iter()
+            .map(|(deposit_idx, status)| (*deposit_idx, deposit_info(*status)))
+            .collect()
+    }
+
+    fn pairing(deposit_idx: DepositIdx, withdrawal_seq: WithdrawalSeq) -> WithdrawalPairing {
+        WithdrawalPairing::new(deposit_idx, withdrawal_seq)
+    }
 
     #[test]
     fn deposit_info_cursor_advances_over_contiguous_purged_deposits() {
@@ -511,7 +569,9 @@ mod tests {
                 WithdrawalStatusCursor {
                     next_deposit_idx: 0
                 },
-                &[2]
+                &[2],
+                3,
+                &[0, 2]
             ),
             WithdrawalStatusCursor {
                 next_deposit_idx: 0
@@ -522,10 +582,42 @@ mod tests {
                 WithdrawalStatusCursor {
                     next_deposit_idx: 0
                 },
+                &[0, 1],
+                2,
                 &[0, 1]
             ),
             WithdrawalStatusCursor {
                 next_deposit_idx: 2
+            }
+        );
+    }
+
+    #[test]
+    fn withdrawal_status_cursor_skips_missing_pairings_below_pairing_frontier() {
+        assert_eq!(
+            next_withdrawal_status_cursor(
+                WithdrawalStatusCursor {
+                    next_deposit_idx: 0
+                },
+                &[0],
+                3,
+                &[0, 2]
+            ),
+            WithdrawalStatusCursor {
+                next_deposit_idx: 2
+            }
+        );
+        assert_eq!(
+            next_withdrawal_status_cursor(
+                WithdrawalStatusCursor {
+                    next_deposit_idx: 0
+                },
+                &[0, 2],
+                3,
+                &[0, 2]
+            ),
+            WithdrawalStatusCursor {
+                next_deposit_idx: 3
             }
         );
     }
@@ -537,7 +629,9 @@ mod tests {
                 ReimbursementStatusCursor {
                     next_deposit_idx: 0
                 },
-                &[2]
+                &[2],
+                3,
+                &[0, 2]
             ),
             ReimbursementStatusCursor {
                 next_deposit_idx: 0
@@ -548,6 +642,8 @@ mod tests {
                 ReimbursementStatusCursor {
                     next_deposit_idx: 0
                 },
+                &[0, 1],
+                2,
                 &[0, 1]
             ),
             ReimbursementStatusCursor {
@@ -557,13 +653,52 @@ mod tests {
     }
 
     #[test]
-    fn withdrawal_pairing_planner_stops_at_deposit_gap() {
-        let (pairings, cursor) =
-            plan_withdrawal_pairings(WithdrawalPairingCursor::default(), &[0, 1, 3], &[0, 1, 2]);
-
-        assert_eq!(pairings, vec![(0, 0), (1, 1)]);
+    fn reimbursement_status_cursor_skips_missing_withdrawals_below_withdrawal_frontier() {
         assert_eq!(
-            cursor,
+            next_reimbursement_status_cursor(
+                ReimbursementStatusCursor {
+                    next_deposit_idx: 0
+                },
+                &[0],
+                3,
+                &[0, 2]
+            ),
+            ReimbursementStatusCursor {
+                next_deposit_idx: 2
+            }
+        );
+        assert_eq!(
+            next_reimbursement_status_cursor(
+                ReimbursementStatusCursor {
+                    next_deposit_idx: 0
+                },
+                &[0, 2],
+                3,
+                &[0, 2]
+            ),
+            ReimbursementStatusCursor {
+                next_deposit_idx: 3
+            }
+        );
+    }
+
+    #[test]
+    fn withdrawal_pairing_planner_stops_at_deposit_gap() {
+        let deposit_infos = deposit_infos(&[
+            (0, DepositStatus::Complete),
+            (1, DepositStatus::Complete),
+            (3, DepositStatus::Complete),
+        ]);
+        let update = plan_withdrawal_pairings(
+            WithdrawalPairingCursor::default(),
+            &[0, 1, 3],
+            &deposit_infos,
+            &[0, 1, 2],
+        );
+
+        assert_eq!(update.pairings, vec![pairing(0, 0), pairing(1, 1)]);
+        assert_eq!(
+            update.cursor,
             WithdrawalPairingCursor {
                 next_deposit_idx: 2,
                 next_withdrawal_seq: 2
@@ -573,11 +708,55 @@ mod tests {
 
     #[test]
     fn withdrawal_pairing_planner_stops_without_indexed_wrt() {
-        let (pairings, cursor) =
-            plan_withdrawal_pairings(WithdrawalPairingCursor::default(), &[0], &[]);
+        let deposit_infos = deposit_infos(&[(0, DepositStatus::Complete)]);
+        let update = plan_withdrawal_pairings(
+            WithdrawalPairingCursor::default(),
+            &[0],
+            &deposit_infos,
+            &[],
+        );
 
-        assert!(pairings.is_empty());
-        assert_eq!(cursor, WithdrawalPairingCursor::default());
+        assert!(update.pairings.is_empty());
+        assert_eq!(update.cursor, WithdrawalPairingCursor::default());
+    }
+
+    #[test]
+    fn withdrawal_pairing_planner_skips_failed_deposits() {
+        let deposit_infos = deposit_infos(&[
+            (0, DepositStatus::Failed),
+            (1, DepositStatus::Complete),
+            (2, DepositStatus::Complete),
+        ]);
+        let update = plan_withdrawal_pairings(
+            WithdrawalPairingCursor::default(),
+            &[0, 1, 2],
+            &deposit_infos,
+            &[0, 1],
+        );
+
+        assert_eq!(update.pairings, vec![pairing(1, 0), pairing(2, 1)]);
+        assert_eq!(
+            update.cursor,
+            WithdrawalPairingCursor {
+                next_deposit_idx: 3,
+                next_withdrawal_seq: 2
+            }
+        );
+    }
+
+    #[test]
+    fn withdrawal_pairing_planner_stops_at_unresolved_deposit() {
+        let deposit_infos =
+            deposit_infos(&[(0, DepositStatus::InProgress), (1, DepositStatus::Complete)]);
+        let update = plan_withdrawal_pairings(
+            WithdrawalPairingCursor::default(),
+            &[0, 1],
+            &deposit_infos,
+            &[0],
+        );
+
+        assert!(update.pairings.is_empty());
+        assert_eq!(update.cursor, WithdrawalPairingCursor::default());
     }
 
     #[test]
@@ -586,10 +765,12 @@ mod tests {
             next_deposit_idx: 2,
             next_withdrawal_seq: 2,
         };
-        let (pairings, next_cursor) = plan_withdrawal_pairings(cursor, &[0, 1], &[0, 1]);
+        let deposit_infos =
+            deposit_infos(&[(0, DepositStatus::Complete), (1, DepositStatus::Complete)]);
+        let update = plan_withdrawal_pairings(cursor, &[0, 1], &deposit_infos, &[0, 1]);
 
-        assert!(pairings.is_empty());
-        assert_eq!(next_cursor, cursor);
+        assert!(update.pairings.is_empty());
+        assert_eq!(update.cursor, cursor);
     }
 
     #[tokio::test]
@@ -605,7 +786,7 @@ mod tests {
             .put_withdrawal_info(2, &withdrawal_info)
             .expect("put withdrawal info");
         status_db
-            .put_withdrawal_pairings(&[(2, 7)])
+            .put_withdrawal_pairings(&[pairing(2, 7)])
             .expect("put withdrawal pairing");
         status_db
             .put_deposit_info_cursor(2)
@@ -645,7 +826,7 @@ mod tests {
         );
         assert_eq!(
             state.select_withdrawal_status_candidates().await,
-            Vec::<WithdrawalStatusCandidate>::new()
+            Vec::<WithdrawalPairing>::new()
         );
         assert_eq!(
             state.select_reimbursement_status_candidates().await,
@@ -728,12 +909,14 @@ mod tests {
             },
         ];
 
+        let complete_deposit_infos =
+            deposit_infos(&[(0, DepositStatus::Complete), (1, DepositStatus::Complete)]);
         let pairings = state
-            .apply_withdrawal_pairings(&status_db, &[0, 1], &requests)
+            .advance_withdrawal_pairings(&status_db, &[0, 1], &complete_deposit_infos, &requests)
             .await
             .expect("persist withdrawal pairings");
 
-        assert_eq!(pairings, vec![(0, 0), (1, 1)]);
+        assert_eq!(pairings, vec![pairing(0, 0), pairing(1, 1)]);
         assert_eq!(
             state.withdrawal_pairing_cursor().await,
             WithdrawalPairingCursor {
@@ -744,12 +927,47 @@ mod tests {
         let snapshot = status_db
             .get_status_snapshot()
             .expect("load status snapshot");
-        assert_eq!(snapshot.withdrawal_pairings, vec![(0, 0), (1, 1)]);
+        assert_eq!(
+            snapshot.withdrawal_pairings,
+            vec![pairing(0, 0), pairing(1, 1)]
+        );
         assert_eq!(
             snapshot.cursors.withdrawal_pairing,
             WithdrawalPairingCursor {
                 next_deposit_idx: 2,
                 next_withdrawal_seq: 2
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn withdrawal_pairings_persist_cursor_when_skipping_failed_deposits() {
+        let status_db = BridgeStatusDbSled::open_temporary().expect("open status db");
+        let state = BridgeMonitoringState::default();
+        let failed_deposit_infos = deposit_infos(&[(0, DepositStatus::Failed)]);
+
+        let pairings = state
+            .advance_withdrawal_pairings(&status_db, &[0], &failed_deposit_infos, &[])
+            .await
+            .expect("persist skipped deposit cursor");
+
+        assert!(pairings.is_empty());
+        assert_eq!(
+            state.withdrawal_pairing_cursor().await,
+            WithdrawalPairingCursor {
+                next_deposit_idx: 1,
+                next_withdrawal_seq: 0
+            }
+        );
+        let snapshot = status_db
+            .get_status_snapshot()
+            .expect("load status snapshot");
+        assert!(snapshot.withdrawal_pairings.is_empty());
+        assert_eq!(
+            snapshot.cursors.withdrawal_pairing,
+            WithdrawalPairingCursor {
+                next_deposit_idx: 1,
+                next_withdrawal_seq: 0
             }
         );
     }
@@ -769,22 +987,15 @@ mod tests {
             },
         ];
 
+        let complete_deposit_infos =
+            deposit_infos(&[(0, DepositStatus::Complete), (1, DepositStatus::Complete)]);
         state
-            .apply_withdrawal_pairings(&status_db, &[0, 1], &requests)
+            .advance_withdrawal_pairings(&status_db, &[0, 1], &complete_deposit_infos, &requests)
             .await
             .expect("persist withdrawal pairings");
         assert_eq!(
             state.select_withdrawal_status_candidates().await,
-            vec![
-                WithdrawalStatusCandidate {
-                    deposit_idx: 0,
-                    withdrawal_seq: 0
-                },
-                WithdrawalStatusCandidate {
-                    deposit_idx: 1,
-                    withdrawal_seq: 1
-                }
-            ]
+            vec![pairing(0, 0), pairing(1, 1)]
         );
 
         state
@@ -806,17 +1017,14 @@ mod tests {
 
         assert_eq!(
             state.select_withdrawal_status_candidates().await,
-            vec![WithdrawalStatusCandidate {
-                deposit_idx: 1,
-                withdrawal_seq: 1
-            }]
+            vec![pairing(1, 1)]
         );
         let snapshot = status_db
             .get_status_snapshot()
             .expect("load status snapshot");
         assert_eq!(
             snapshot.withdrawal_pairings,
-            vec![(1, 1)],
+            vec![pairing(1, 1)],
             "confirmed withdrawal pairings below the cursor are purged"
         );
         assert_eq!(
@@ -833,7 +1041,7 @@ mod tests {
     async fn pairing_gc_retries_below_cursor() {
         let status_db = BridgeStatusDbSled::open_temporary().expect("open status db");
         status_db
-            .put_withdrawal_pairings(&[(0, 0), (1, 1)])
+            .put_withdrawal_pairings(&[pairing(0, 0), pairing(1, 1)])
             .expect("put withdrawal pairings");
         status_db
             .put_withdrawal_status_cursor(WithdrawalStatusCursor {
@@ -854,14 +1062,86 @@ mod tests {
         let snapshot = status_db
             .get_status_snapshot()
             .expect("load status snapshot");
-        assert_eq!(snapshot.withdrawal_pairings, vec![(1, 1)]);
+        assert_eq!(snapshot.withdrawal_pairings, vec![pairing(1, 1)]);
         assert_eq!(
             state.select_withdrawal_status_candidates().await,
-            vec![WithdrawalStatusCandidate {
-                deposit_idx: 1,
-                withdrawal_seq: 1
-            }]
+            vec![pairing(1, 1)]
         );
+    }
+
+    #[tokio::test]
+    async fn pairing_gc_skips_missing_pairings_below_pairing_frontier() {
+        let status_db = BridgeStatusDbSled::open_temporary().expect("open status db");
+        status_db
+            .put_withdrawal_pairings(&[pairing(0, 0), pairing(2, 1)])
+            .expect("put withdrawal pairings");
+        status_db
+            .put_withdrawal_pairing_cursor(WithdrawalPairingCursor {
+                next_deposit_idx: 3,
+                next_withdrawal_seq: 2,
+            })
+            .expect("put withdrawal pairing cursor");
+
+        let snapshot = status_db
+            .get_status_snapshot()
+            .expect("load status snapshot");
+        let state = BridgeMonitoringState::from_snapshot(snapshot);
+
+        state
+            .apply_withdrawal_updates(
+                &status_db,
+                vec![WithdrawalInfoUpdate {
+                    deposit_idx: 0,
+                    info: WithdrawalInfo {
+                        withdrawal_request_txid: Buf32([20; 32]),
+                        fulfillment_txid: Some(Txid::from_byte_array([21; 32])),
+                        status: WithdrawalStatus::Complete,
+                    },
+                    confirmations: Some(6),
+                }],
+                6,
+            )
+            .await
+            .expect("persist withdrawal status");
+
+        let snapshot = status_db
+            .get_status_snapshot()
+            .expect("load status snapshot");
+        assert_eq!(
+            snapshot.cursors.withdrawal_status,
+            WithdrawalStatusCursor {
+                next_deposit_idx: 2
+            }
+        );
+        assert_eq!(snapshot.withdrawal_pairings, vec![pairing(2, 1)]);
+
+        state
+            .apply_withdrawal_updates(
+                &status_db,
+                vec![WithdrawalInfoUpdate {
+                    deposit_idx: 2,
+                    info: WithdrawalInfo {
+                        withdrawal_request_txid: Buf32([22; 32]),
+                        fulfillment_txid: Some(Txid::from_byte_array([23; 32])),
+                        status: WithdrawalStatus::Complete,
+                    },
+                    confirmations: Some(6),
+                }],
+                6,
+            )
+            .await
+            .expect("persist withdrawal status");
+
+        let snapshot = status_db
+            .get_status_snapshot()
+            .expect("load status snapshot");
+        assert_eq!(
+            snapshot.cursors.withdrawal_status,
+            WithdrawalStatusCursor {
+                next_deposit_idx: 3
+            }
+        );
+        assert!(snapshot.withdrawal_pairings.is_empty());
     }
 
     #[tokio::test]
@@ -929,8 +1209,9 @@ mod tests {
             Vec::<DepositIdx>::new()
         );
 
+        let complete_deposit_infos = deposit_infos(&[(0, DepositStatus::Complete)]);
         state
-            .apply_withdrawal_pairings(&status_db, &[0], &requests)
+            .advance_withdrawal_pairings(&status_db, &[0], &complete_deposit_infos, &requests)
             .await
             .expect("persist withdrawal pairings");
         assert_eq!(
@@ -1054,6 +1335,100 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn reimbursement_gc_skips_missing_withdrawals_below_withdrawal_frontier() {
+        let status_db = BridgeStatusDbSled::open_temporary().expect("open status db");
+        status_db
+            .put_withdrawal_info(
+                0,
+                &WithdrawalInfo {
+                    withdrawal_request_txid: Buf32([30; 32]),
+                    fulfillment_txid: Some(Txid::from_byte_array([31; 32])),
+                    status: WithdrawalStatus::Complete,
+                },
+            )
+            .expect("put withdrawal info");
+        status_db
+            .put_withdrawal_info(
+                2,
+                &WithdrawalInfo {
+                    withdrawal_request_txid: Buf32([32; 32]),
+                    fulfillment_txid: Some(Txid::from_byte_array([33; 32])),
+                    status: WithdrawalStatus::Complete,
+                },
+            )
+            .expect("put withdrawal info");
+        status_db
+            .put_withdrawal_status_cursor(WithdrawalStatusCursor {
+                next_deposit_idx: 3,
+            })
+            .expect("put withdrawal cursor");
+
+        let snapshot = status_db
+            .get_status_snapshot()
+            .expect("load status snapshot");
+        let state = BridgeMonitoringState::from_snapshot(snapshot);
+
+        state
+            .apply_reimbursement_updates(
+                &status_db,
+                vec![ReimbursementInfoUpdate {
+                    deposit_idx: 0,
+                    info: ReimbursementInfo {
+                        claim_txid: Txid::from_byte_array([34; 32]),
+                        challenge_step: crate::types::ChallengeStep::NotApplicable,
+                        payout_txid: Some(Txid::from_byte_array([35; 32])),
+                        status: ReimbursementStatus::Complete,
+                    },
+                    confirmations: Some(6),
+                }],
+                6,
+            )
+            .await
+            .expect("persist reimbursement status");
+
+        let snapshot = status_db
+            .get_status_snapshot()
+            .expect("load status snapshot");
+        assert_eq!(
+            snapshot.cursors.reimbursement_status,
+            ReimbursementStatusCursor {
+                next_deposit_idx: 2
+            }
+        );
+        assert_eq!(snapshot.withdrawals.len(), 1);
+        assert_eq!(snapshot.withdrawals[0].0, 2);
+
+        state
+            .apply_reimbursement_updates(
+                &status_db,
+                vec![ReimbursementInfoUpdate {
+                    deposit_idx: 2,
+                    info: ReimbursementInfo {
+                        claim_txid: Txid::from_byte_array([36; 32]),
+                        challenge_step: crate::types::ChallengeStep::NotApplicable,
+                        payout_txid: Some(Txid::from_byte_array([37; 32])),
+                        status: ReimbursementStatus::Complete,
+                    },
+                    confirmations: Some(6),
+                }],
+                6,
+            )
+            .await
+            .expect("persist reimbursement status");
+
+        let snapshot = status_db
+            .get_status_snapshot()
+            .expect("load status snapshot");
+        assert_eq!(
+            snapshot.cursors.reimbursement_status,
+            ReimbursementStatusCursor {
+                next_deposit_idx: 3
+            }
+        );
+        assert!(snapshot.withdrawals.is_empty());
+    }
+
+    #[tokio::test]
     async fn reimbursement_candidates_skip_incomplete_withdrawals() {
         let status_db = BridgeStatusDbSled::open_temporary().expect("open status db");
         let state = BridgeMonitoringState::default();
@@ -1093,8 +1468,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reimbursement_candidates_include_withdrawal_cursor_lag() {
+    async fn reimbursement_candidates_use_retained_complete_rows_when_cursor_lags() {
         let status_db = BridgeStatusDbSled::open_temporary().expect("open status db");
+        status_db
+            .put_withdrawal_info(
+                2,
+                &WithdrawalInfo {
+                    withdrawal_request_txid: Buf32([13; 32]),
+                    fulfillment_txid: Some(Txid::from_byte_array([14; 32])),
+                    status: WithdrawalStatus::Complete,
+                },
+            )
+            .expect("put withdrawal info");
         status_db
             .put_withdrawal_status_cursor(WithdrawalStatusCursor {
                 next_deposit_idx: 3,
@@ -1113,7 +1498,7 @@ mod tests {
 
         assert_eq!(
             state.select_reimbursement_status_candidates().await,
-            vec![1, 2]
+            vec![2]
         );
     }
 }

--- a/backend/crates/bridge/src/status.rs
+++ b/backend/crates/bridge/src/status.rs
@@ -72,9 +72,32 @@ pub async fn bridge_monitoring_task(
             .state()
             .select_deposit_info_candidates(&deposit_indices)
             .await;
-        let deposit_infos = get_deposits(context.bridge_rpc(), &deposit_candidates).await;
-        let deposit_info_updates =
-            get_deposit_info_updates(context.esplora(), chain_tip_height, deposit_infos).await;
+        let pairing_cursor = context.state().withdrawal_pairing_cursor().await;
+        let withdrawal_pairing_batch_size = context.config().withdrawal_pairing_batch_size();
+        let pairing_deposit_candidates =
+            deposit_indices_from(&deposit_indices, pairing_cursor.next_deposit_idx)
+                .into_iter()
+                .take(withdrawal_pairing_batch_size)
+                .collect::<Vec<_>>();
+        let all_deposit_candidates = deposit_candidates
+            .iter()
+            .chain(pairing_deposit_candidates.iter())
+            .copied()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let deposit_infos = get_deposits(context.bridge_rpc(), &all_deposit_candidates).await;
+        let deposit_candidates = deposit_candidates.into_iter().collect::<BTreeSet<_>>();
+        let deposit_info_updates = get_deposit_info_updates(
+            context.esplora(),
+            chain_tip_height,
+            deposit_infos
+                .iter()
+                .copied()
+                .filter(|(deposit_idx, _)| deposit_candidates.contains(deposit_idx))
+                .collect(),
+        )
+        .await;
         if let Err(e) = context
             .state()
             .apply_deposit_info_updates(
@@ -87,18 +110,27 @@ pub async fn bridge_monitoring_task(
             warn!(error = %e, "failed to persist deposit status updates");
         }
 
-        let pairing_cursor = context.state().withdrawal_pairing_cursor().await;
-        let new_deposit_indices_count =
-            count_deposit_indices_from(&deposit_indices, pairing_cursor.next_deposit_idx);
+        let pairing_deposit_candidates = pairing_deposit_candidates
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+        let pairing_deposit_infos = deposit_infos
+            .into_iter()
+            .filter(|(deposit_idx, _)| pairing_deposit_candidates.contains(deposit_idx))
+            .collect::<Vec<_>>();
         let withdrawal_requests = fetch_withdrawal_requests(
             context.withdrawal_index(),
             pairing_cursor.next_withdrawal_seq,
-            new_deposit_indices_count,
-            context.config().withdrawal_pairing_batch_size(),
+            pairing_deposit_candidates.len(),
+            withdrawal_pairing_batch_size,
         );
         let new_pairings = match context
             .state()
-            .apply_withdrawal_pairings(context.status_db(), &deposit_indices, &withdrawal_requests)
+            .advance_withdrawal_pairings(
+                context.status_db(),
+                &deposit_indices,
+                &pairing_deposit_infos,
+                &withdrawal_requests,
+            )
             .await
         {
             Ok(pairings) => pairings,
@@ -121,7 +153,7 @@ pub async fn bridge_monitoring_task(
             context.esplora(),
             chain_tip_height,
             &withdrawal_candidates,
-            context.config().withdrawal_pairing_batch_size(),
+            withdrawal_pairing_batch_size,
         )
         .await;
         if let Err(e) = context
@@ -165,26 +197,34 @@ pub async fn bridge_monitoring_task(
     Ok(())
 }
 
+#[cfg(test)]
 fn count_deposit_indices_from(
     deposit_indices: &[DepositIdx],
     next_deposit_idx: DepositIdx,
 ) -> usize {
-    // This mirrors the state pairing planner's contiguous-prefix rule. The
-    // status tick uses this count to size DB reads; state still enforces the
-    // pairing invariant when it applies the fetched rows.
+    deposit_indices_from(deposit_indices, next_deposit_idx).len()
+}
+
+fn deposit_indices_from(
+    deposit_indices: &[DepositIdx],
+    next_deposit_idx: DepositIdx,
+) -> Vec<DepositIdx> {
+    // This collects the contiguous deposit-index window known to the bridge.
+    // The state pairing planner additionally checks deposit status and skips
+    // failed deposits without consuming withdrawal requests.
     let deposit_indices = deposit_indices.iter().copied().collect::<BTreeSet<_>>();
     let mut next_deposit_idx = next_deposit_idx;
-    let mut count = 0;
+    let mut indices = Vec::new();
 
     while deposit_indices.contains(&next_deposit_idx) {
-        count += 1;
+        indices.push(next_deposit_idx);
         let Some(next) = next_deposit_idx.checked_add(1) else {
             break;
         };
         next_deposit_idx = next;
     }
 
-    count
+    indices
 }
 
 /// Fetch detailed information for all deposits.

--- a/backend/crates/bridge/src/types.rs
+++ b/backend/crates/bridge/src/types.rs
@@ -39,6 +39,22 @@ pub(crate) struct WithdrawalPairingCursor {
     pub(crate) next_withdrawal_seq: WithdrawalSeq,
 }
 
+/// Committed withdrawal-to-deposit pairing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct WithdrawalPairing {
+    pub(crate) deposit_idx: DepositIdx,
+    pub(crate) withdrawal_seq: WithdrawalSeq,
+}
+
+impl WithdrawalPairing {
+    pub(crate) fn new(deposit_idx: DepositIdx, withdrawal_seq: WithdrawalSeq) -> Self {
+        Self {
+            deposit_idx,
+            withdrawal_seq,
+        }
+    }
+}
+
 /// In-memory cursor for bridge withdrawal status polling progress.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct WithdrawalStatusCursor {

--- a/backend/crates/bridge/src/withdrawal_status.rs
+++ b/backend/crates/bridge/src/withdrawal_status.rs
@@ -7,8 +7,8 @@ use super::{
     bridge_rpc::{self, RpcClientManager},
     db::traits::WithdrawalIndexerDb,
     esplora::{self, EsploraClient},
-    state::{WithdrawalInfoUpdate, WithdrawalStatusCandidate},
-    types::{WithdrawalInfo, WithdrawalStatus},
+    state::WithdrawalInfoUpdate,
+    types::{WithdrawalInfo, WithdrawalPairing, WithdrawalStatus},
     withdrawal_requests,
 };
 
@@ -23,7 +23,7 @@ pub(crate) async fn get_withdrawal_updates(
     withdrawal_index: &impl WithdrawalIndexerDb,
     esplora_client: &EsploraClient,
     chain_tip_height: L1Height,
-    candidates: &[WithdrawalStatusCandidate],
+    candidates: &[WithdrawalPairing],
     batch_size: usize,
 ) -> Vec<WithdrawalInfoUpdate> {
     let Some(first_candidate) = candidates.first() else {


### PR DESCRIPTION
## Description

Fixes withdrawal pairing when bridge deposit indices include failed/aborted deposits.

Additionally some refactor.

### Changes

- Skip failed deposits during withdrawal pairing without consuming a withdrawal request.
- Bound pairing deposit-info fetches by `withdrawal_pairing_batch_size`.
- Advance withdrawal/reimbursement GC cursors across sparse pairing and withdrawal-handoff domains.
- Keep reimbursement candidates based on retained complete withdrawal rows.
- Add test coverage for failed-deposit pairing, sparse pairing GC, and sparse reimbursement handoff GC.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor

## How Has This Been Tested?

New/updated coverage includes:
`withdrawal_pairing_planner_skips_failed_deposits`
`withdrawal_pairings_persist_cursor_when_skipping_failed_deposits`
`withdrawal_status_cursor_skips_missing_pairings_below_pairing_frontier`
`pairing_gc_skips_missing_pairings_below_pairing_frontier`
`reimbursement_status_cursor_skips_missing_withdrawals_below_withdrawal_frontier`
`reimbursement_gc_skips_missing_withdrawals_below_withdrawal_frontier`
Updated the reimbursement lag test to use retained complete withdrawal rows instead of dense cursor ranges.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 