### PR TITLE
fix(network): probe EVM RPC with eth_blockNumber

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -957,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/backend/crates/config/src/lib.rs
+++ b/backend/crates/config/src/lib.rs
@@ -365,8 +365,8 @@ host = "0.0.0.0"
 port = 3000
 
 [network]
-sequencer_url = "https://rpc.testnet.alpenlabs.io"
-rpc_url = "https://rpc.testnet.alpenlabs.io"
+sequencer_url = "https://strata.testnet.alpenlabs.io"
+rpc_url = "https://alpen.testnet.alpenlabs.io"
 bundler_url = "https://bundler.testnet.alpenlabs.io/health"
 retry_policy_max_retries = 5
 retry_policy_total_time_s = 60
@@ -397,7 +397,7 @@ public_key = "02badcafe111111111111111111111111111111111111111111111111111111111
 rpc_url = "https://bridge.testnet.alpenlabs.io/4"
 
 [withdrawal_indexer]
-eth_rpc_url = "https://rpc.testnet.alpenlabs.io"
+eth_rpc_url = "https://alpen.testnet.alpenlabs.io"
 withdrawal_denomination_sats = 100000000
 "#;
 

--- a/backend/crates/network/src/status.rs
+++ b/backend/crates/network/src/status.rs
@@ -13,23 +13,33 @@ use status_config::NetworkMonitoringConfig;
 use status_utils::{create_rpc_client, ExponentialBackoff};
 
 const STRATA_CHAIN_STATUS_METHOD: &str = "strata_getChainStatus";
+const ETH_BLOCK_NUMBER_METHOD: &str = "eth_blockNumber";
 
 fn is_chain_status_response_online(json: &serde_json::Value) -> bool {
     json.get("tip").is_some()
 }
 
-/// Calls `strata_getChainStatus` using `jsonrpsee`.
-async fn call_rpc_status(client: &HttpClient, retry_policy: ExponentialBackoff) -> Status {
+fn is_eth_block_number_response_online(json: &serde_json::Value) -> bool {
+    json.as_str()
+        .and_then(|block_number| block_number.strip_prefix("0x"))
+        .and_then(|block_number| u64::from_str_radix(block_number, 16).ok())
+        .is_some()
+}
+
+async fn call_json_rpc_status(
+    client: &HttpClient,
+    method: &'static str,
+    is_online: impl Fn(&serde_json::Value) -> bool,
+    retry_policy: ExponentialBackoff,
+) -> Status {
     let mut retry_count: u64 = 0;
 
     loop {
-        let response: Result<serde_json::Value, _> = client
-            .request(STRATA_CHAIN_STATUS_METHOD, Vec::<()>::new())
-            .await;
+        let response: Result<serde_json::Value, _> = client.request(method, Vec::<()>::new()).await;
         match response {
             Ok(json) => {
-                info!(?json, method = STRATA_CHAIN_STATUS_METHOD, "rpc response");
-                if is_chain_status_response_online(&json) {
+                info!(?json, method, "rpc response");
+                if is_online(&json) {
                     return Status::Online;
                 } else {
                     return Status::Offline;
@@ -41,9 +51,7 @@ async fn call_rpc_status(client: &HttpClient, retry_policy: ExponentialBackoff) 
                     if delay_seconds > 0 {
                         info!(
                             delay_seconds,
-                            retry_count,
-                            method = STRATA_CHAIN_STATUS_METHOD,
-                            "retrying rpc status request"
+                            retry_count, method, "retrying rpc status request"
                         );
                         sleep(Duration::from_secs(delay_seconds)).await;
                     }
@@ -51,7 +59,7 @@ async fn call_rpc_status(client: &HttpClient, retry_policy: ExponentialBackoff) 
                 } else {
                     error!(
                         error = %e,
-                        method = STRATA_CHAIN_STATUS_METHOD,
+                        method,
                         "could not get network status"
                     );
                     return Status::Offline;
@@ -59,6 +67,28 @@ async fn call_rpc_status(client: &HttpClient, retry_policy: ExponentialBackoff) 
             }
         }
     }
+}
+
+/// Calls the OL `strata_getChainStatus` method.
+async fn call_sequencer_status(client: &HttpClient, retry_policy: ExponentialBackoff) -> Status {
+    call_json_rpc_status(
+        client,
+        STRATA_CHAIN_STATUS_METHOD,
+        is_chain_status_response_online,
+        retry_policy,
+    )
+    .await
+}
+
+/// Calls the EVM `eth_blockNumber` method.
+async fn call_rpc_endpoint_status(client: &HttpClient, retry_policy: ExponentialBackoff) -> Status {
+    call_json_rpc_status(
+        client,
+        ETH_BLOCK_NUMBER_METHOD,
+        is_eth_block_number_response_online,
+        retry_policy,
+    )
+    .await
 }
 
 /// Checks bundler health (`/health`)
@@ -96,8 +126,10 @@ pub async fn network_monitoring_task(
         }
 
         let sequencer =
-            call_rpc_status(&sequencer_client, context.config().sequencer_retry_policy()).await;
-        let rpc_endpoint = call_rpc_status(&rpc_client, context.config().rpc_retry_policy()).await;
+            call_sequencer_status(&sequencer_client, context.config().sequencer_retry_policy())
+                .await;
+        let rpc_endpoint =
+            call_rpc_endpoint_status(&rpc_client, context.config().rpc_retry_policy()).await;
         let bundler_endpoint = check_bundler_health(&http_client, context.config()).await;
 
         let new_status = NetworkStatus::new(sequencer, rpc_endpoint, bundler_endpoint);
@@ -133,7 +165,7 @@ pub async fn get_network_status(
 mod tests {
     use serde_json::json;
 
-    use super::is_chain_status_response_online;
+    use super::{is_chain_status_response_online, is_eth_block_number_response_online};
 
     #[test]
     fn chain_status_response_with_tip_is_online() {
@@ -156,6 +188,23 @@ mod tests {
             "confirmed": {},
             "finalized": {},
             "latest": {}
+        })));
+    }
+
+    #[test]
+    fn eth_block_number_response_with_hex_string_is_online() {
+        assert!(is_eth_block_number_response_online(&json!("0x1a")));
+    }
+
+    #[test]
+    fn eth_block_number_response_with_non_hex_string_is_offline() {
+        assert!(!is_eth_block_number_response_online(&json!("latest")));
+    }
+
+    #[test]
+    fn eth_block_number_response_with_object_is_offline() {
+        assert!(!is_eth_block_number_response_online(&json!({
+            "blockNumber": "0x1a"
         })));
     }
 }

--- a/backend/example-config.toml
+++ b/backend/example-config.toml
@@ -12,8 +12,8 @@ datadir = "data"
   initial_status_wait_timeout_s = 30
   retry_policy_max_retries      = 5
   retry_policy_total_time_s     = 60
-  rpc_url                       = "https://rpc-staging.testnet-v2.alpenlabs.io"
-  sequencer_url                 = "https://rpc-staging.testnet-v2.alpenlabs.io"
+  rpc_url                       = "https://alpen-staging.testnet-v2.alpenlabs.io"
+  sequencer_url                 = "https://strata-staging.testnet-v2.alpenlabs.io"
   status_refetch_interval_s     = 10
 
 # Bridge monitoring configuration


### PR DESCRIPTION
## Summary
- use `strata_getChainStatus` only for the OL/sequencer status probe
- use `eth_blockNumber` for the public EVM RPC endpoint probe
- update example/config test endpoints to distinguish OL and EVM RPC surfaces
- add unit coverage for EVM block-number response validation

Fixes STR-3707.

## Validation
- `cargo test -p status-network -p status-config --lib --locked`
- `cargo check -p status-network -p status-config --locked`
- `rustfmt --edition 2021 --check backend/crates/network/src/status.rs backend/crates/config/src/lib.rs`
- `git diff --check`

## Follow-up
- After merge, publish a new backend image and update deployment values with the new image tag.