### PR TITLE
feat(bridge)!: require configured operator names

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3995,6 +3995,7 @@ dependencies = [
 name = "status-config"
 version = "0.2.0"
 dependencies = [
+ "bitcoin",
  "serde",
  "status-utils",
  "toml",

--- a/backend/crates/bridge/src/bridge_rpc.rs
+++ b/backend/crates/bridge/src/bridge_rpc.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
+use bitcoin::PublicKey;
 use jsonrpsee::http_client::HttpClient;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, future::Future};
 use strata_bridge_primitives::types::DepositIdx;
 use strata_bridge_rpc::traits::{StrataBridgeControlApiClient, StrataBridgeMonitoringApiClient};
 use strata_bridge_rpc::types::{
@@ -54,10 +55,10 @@ impl RpcClientManager {
     pub(crate) fn new(config: &BridgeMonitoringConfig) -> Self {
         let mut clients = BTreeMap::new();
         for operator in config.operators() {
-            clients.insert(
-                operator.public_key().to_string(),
-                create_rpc_client(operator.rpc_url()),
-            );
+            let operator_pk = operator.public_key().to_string();
+            if let Some(rpc_url) = operator.rpc_url() {
+                clients.insert(operator_pk, create_rpc_client(rpc_url));
+            }
         }
 
         Self { clients }
@@ -107,7 +108,7 @@ impl RpcClientManager {
     async fn query_clients_with_retry<T, F, Fut>(&self, operation: F) -> Option<T>
     where
         F: Fn(HttpClient) -> Fut,
-        Fut: std::future::Future<Output = Result<T, Box<dyn std::error::Error + Send + Sync>>>,
+        Fut: Future<Output = Result<T, Box<dyn std::error::Error + Send + Sync>>>,
     {
         // BTreeMap maintains sorted order automatically.
         for (client_key, client) in self.clients.iter() {
@@ -150,21 +151,32 @@ impl RpcClientManager {
 /// Fetch operator status.
 pub(crate) async fn get_operator_status(
     rpc_manager: &RpcClientManager,
-    operator_public_key: &str,
+    operator_pk: PublicKey,
 ) -> RpcOperatorStatus {
-    let Some(client) = rpc_manager.client(operator_public_key) else {
-        warn!(
-            operator_pk = %operator_public_key,
-            "missing bridge operator RPC client"
-        );
-        return RpcOperatorStatus::Offline;
+    let operator_pk_str = operator_pk.to_string();
+    let Some(client) = rpc_manager.client(&operator_pk_str) else {
+        return rpc_manager
+            .query_clients_with_retry(|client| async move {
+                client
+                    .get_operator_status(operator_pk)
+                    .await
+                    .map_err(|e| e.into())
+            })
+            .await
+            .unwrap_or_else(|| {
+                warn!(
+                    operator_pk = %operator_pk_str,
+                    "failed to fetch bridge operator status from peer clients"
+                );
+                RpcOperatorStatus::Offline
+            });
     };
 
     match client.get_uptime().await {
         Ok(_) => RpcOperatorStatus::Online,
         Err(e) => {
             warn!(
-                operator_pk = %operator_public_key,
+                operator_pk = %operator_pk_str,
                 error = %e,
                 "failed to fetch bridge operator uptime"
             );

--- a/backend/crates/bridge/src/status.rs
+++ b/backend/crates/bridge/src/status.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use axum::http::StatusCode;
 use axum::Json;
-use bitcoin::{secp256k1::PublicKey, Txid};
+use bitcoin::Txid;
 use std::{collections::BTreeSet, sync::Arc};
 use strata_bridge_primitives::types::DepositIdx;
 use strata_primitives::L1Height;
@@ -40,13 +40,14 @@ pub async fn bridge_monitoring_task(
 
         let mut operator_statuses = Vec::new();
 
-        for (index, operator) in context.config().operators().iter().enumerate() {
-            let operator_id = format!("Alpen Labs #{}", index + 1);
-            let pk_bytes = hex::decode(operator.public_key()).expect("decode to succeed");
-            let operator_pk = PublicKey::from_slice(&pk_bytes).expect("conversion to succeed");
-            let status =
-                bridge_rpc::get_operator_status(context.bridge_rpc(), operator.public_key()).await;
-            operator_statuses.push(OperatorStatus::new(operator_id, operator_pk, status));
+        for operator in context.config().operators() {
+            let operator_pk = *operator.public_key();
+            let status = bridge_rpc::get_operator_status(context.bridge_rpc(), operator_pk).await;
+            operator_statuses.push(OperatorStatus::new(
+                operator.name().to_owned(),
+                operator_pk,
+                status,
+            ));
         }
 
         context.state().update_operators(operator_statuses).await;

--- a/backend/crates/bridge/src/types.rs
+++ b/backend/crates/bridge/src/types.rs
@@ -1,4 +1,4 @@
-use bitcoin::{secp256k1::PublicKey, Txid};
+use bitcoin::{PublicKey, Txid};
 use serde::{Deserialize, Serialize};
 use strata_bridge_primitives::types::DepositIdx;
 use strata_bridge_rpc::types::{

--- a/backend/crates/config/Cargo.toml
+++ b/backend/crates/config/Cargo.toml
@@ -9,6 +9,7 @@
 [dependencies]
   status-utils.workspace = true
 
+  bitcoin.workspace = true
   serde.workspace   = true
   toml.workspace    = true
   tracing.workspace = true

--- a/backend/crates/config/src/lib.rs
+++ b/backend/crates/config/src/lib.rs
@@ -1,3 +1,4 @@
+use bitcoin::PublicKey;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use tracing::{debug, trace};
@@ -9,10 +10,13 @@ use status_utils::ExponentialBackoff;
 pub struct Config {
     /// Base directory for persisted dashboard data.
     datadir: PathBuf,
+
     /// API server configuration
     server: ApiServerConfig,
+
     /// Network monitoring configuration
     network: NetworkMonitoringConfig,
+
     /// Bridge monitoring configuration
     bridge: BridgeMonitoringConfig,
 
@@ -25,6 +29,7 @@ pub struct Config {
 pub struct ApiServerConfig {
     /// Host address to bind the server to
     host: String,
+
     /// Port number to bind the server to
     port: u16,
 }
@@ -250,19 +255,27 @@ impl WithdrawalIndexerConfig {
 /// Configuration for a bridge operator
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BridgeOperator {
+    /// Display name of the bridge operator
+    name: String,
+
     /// Public key of the bridge operator
-    public_key: String,
-    /// RPC URL for the bridge operator
-    rpc_url: String,
+    public_key: PublicKey,
+
+    /// RPC URL for the bridge operator.
+    rpc_url: Option<String>,
 }
 
 impl BridgeOperator {
-    pub fn public_key(&self) -> &str {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn public_key(&self) -> &PublicKey {
         &self.public_key
     }
 
-    pub fn rpc_url(&self) -> &str {
-        &self.rpc_url
+    pub fn rpc_url(&self) -> Option<&str> {
+        self.rpc_url.as_deref()
     }
 }
 
@@ -381,19 +394,23 @@ status_refetch_interval_s = 120
 initial_status_wait_timeout_s = 5
 
 [[bridge.operators]]
-public_key = "02deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+name = "Operator 1"
+public_key = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
 rpc_url = "https://bridge.testnet.alpenlabs.io/1"
 
 [[bridge.operators]]
-public_key = "02cafebabe1234567890abcdef1234567890abcdef1234567890abcdef123456"
+name = "Operator 2"
+public_key = "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5"
 rpc_url = "https://bridge.testnet.alpenlabs.io/2"
 
 [[bridge.operators]]
-public_key = "02f00dbabe9876543210fedcba9876543210fedcba9876543210fedcba987654"
+name = "Operator 3"
+public_key = "02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9"
 rpc_url = "https://bridge.testnet.alpenlabs.io/3"
 
 [[bridge.operators]]
-public_key = "02badcafe1111111111111111111111111111111111111111111111111111111111"
+name = "Operator 4"
+public_key = "02e493dbf1c10d80f3581e4904930b1404cc6c13900ee0758474fa94abe8c4cd13"
 rpc_url = "https://bridge.testnet.alpenlabs.io/4"
 
 [withdrawal_indexer]
@@ -491,11 +508,13 @@ initial_status_wait_timeout_s = 7
 withdrawal_pairing_batch_size = 500
 
 [[bridge.operators]]
-public_key = "02deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+name = "Operator 1"
+public_key = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
 rpc_url = "https://bridge.example.com/1"
 
 [[bridge.operators]]
-public_key = "02cafebabe1234567890abcdef1234567890abcdef1234567890abcdef123456"
+name = "Operator 2"
+public_key = "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5"
 rpc_url = "https://bridge.example.com/2"
 
 [withdrawal_indexer]
@@ -527,21 +546,23 @@ withdrawal_denomination_sats = 100000000
         assert_eq!(config.bridge.initial_status_wait_timeout_s(), 7);
         assert_eq!(config.bridge.withdrawal_pairing_batch_size(), 500);
         assert_eq!(config.bridge.operators().len(), 2);
+        assert_eq!(config.bridge.operators()[0].name(), "Operator 1");
         assert_eq!(
-            config.bridge.operators()[0].public_key(),
-            "02deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+            config.bridge.operators()[0].public_key().to_string(),
+            "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
         );
         assert_eq!(
             config.bridge.operators()[0].rpc_url(),
-            "https://bridge.example.com/1"
+            Some("https://bridge.example.com/1")
         );
+        assert_eq!(config.bridge.operators()[1].name(), "Operator 2");
         assert_eq!(
-            config.bridge.operators()[1].public_key(),
-            "02cafebabe1234567890abcdef1234567890abcdef1234567890abcdef123456"
+            config.bridge.operators()[1].public_key().to_string(),
+            "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5"
         );
         assert_eq!(
             config.bridge.operators()[1].rpc_url(),
-            "https://bridge.example.com/2"
+            Some("https://bridge.example.com/2")
         );
         assert_eq!(
             config.withdrawal_indexer().eth_rpc_url(),
@@ -555,6 +576,77 @@ withdrawal_denomination_sats = 100000000
             config.withdrawal_indexer().withdrawal_denomination_sats(),
             100_000_000
         );
+    }
+
+    #[test]
+    fn bridge_operator_name_is_required() {
+        let config_content = r#"
+datadir = "data"
+
+[server]
+host = "127.0.0.1"
+port = 8080
+
+[network]
+sequencer_url = ""
+rpc_url = ""
+bundler_url = ""
+retry_policy_max_retries = 0
+retry_policy_total_time_s = 0
+status_refetch_interval_s = 0
+
+[bridge]
+esplora_url = ""
+max_tx_confirmations = 0
+status_refetch_interval_s = 0
+
+[[bridge.operators]]
+public_key = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+rpc_url = "https://bridge.example.com/1"
+
+[withdrawal_indexer]
+eth_rpc_url = "https://rpc.example.com"
+"#;
+
+        let error = toml::from_str::<Config>(config_content).expect_err("missing operator name");
+        assert!(
+            error.to_string().contains("missing field `name`"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn bridge_operator_rpc_url_is_optional() {
+        let config_content = r#"
+datadir = "data"
+
+[server]
+host = "127.0.0.1"
+port = 8080
+
+[network]
+sequencer_url = ""
+rpc_url = ""
+bundler_url = ""
+retry_policy_max_retries = 0
+retry_policy_total_time_s = 0
+status_refetch_interval_s = 0
+
+[bridge]
+esplora_url = ""
+max_tx_confirmations = 0
+status_refetch_interval_s = 0
+
+[[bridge.operators]]
+name = "External Operator"
+public_key = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+
+[withdrawal_indexer]
+eth_rpc_url = "https://rpc.example.com"
+"#;
+
+        let config = toml::from_str::<Config>(config_content).expect("parse config");
+        assert_eq!(config.bridge.operators()[0].rpc_url(), None);
     }
 
     #[test]

--- a/backend/example-config.toml
+++ b/backend/example-config.toml
@@ -27,16 +27,23 @@ datadir = "data"
 
   # Bridge operators configuration
   [[bridge.operators]]
-    public_key = "025f9bfac3b160a0b9129d558ce29ab2df66ebbdd85dec1f5a2faf2e9de07acdfd"
-    rpc_url    = "http://localhost:54231"
+    name       = "Alpen Labs #1"
+    public_key = "02157d08fa2eb6071cef0750bcf1c0c9e94c2f05f629cdbdb3982851dce9472cd0"
+    rpc_url    = "http://localhost:54195"
 
   [[bridge.operators]]
-    public_key = "027098a1e38159f586536fabcb5537cdbb1454b1464c5c4a1bfd48de6c794d28c4"
-    rpc_url    = "http://localhost:54232"
+    name       = "Alpen Labs #2"
+    public_key = "02444d7dca618168c1c4963a1556c2cab7d9172f0702cc3498dff72015717c0968"
+    rpc_url    = "http://localhost:54367"
 
   [[bridge.operators]]
-    public_key = "0288610184701307eef5dbb81ce1d974bc6940d21601a9656b565dab485321a03f"
-    rpc_url    = "http://localhost:54233"
+    name       = "Alpen Labs #3"
+    public_key = "02bff82939acd1deaeed90d6620b64ec475c6ff80a30fd07fca05315ddb1df873d"
+    rpc_url    = "http://localhost:54492"
+
+  [[bridge.operators]]
+    name       = "External Operator #1"
+    public_key = "02a96ec5406c02be9b6a7b254af44acf15b23b908b21619f9be583d82f943b6fb2"
 
 # Withdrawal-intent indexer configuration
 [withdrawal_indexer]


### PR DESCRIPTION
## Description

Adds explicit bridge operator names and supports peer-reported status for operators without a direct RPC endpoint.

## Changes

- Require `bridge.operators[*].name` in backend config instead of generating display names.
- Parse bridge operator public keys at config load time.
- Make `bridge.operators[*].rpc_url` optional.
- Use `get_uptime` for status of operators with `rpc_url`.
- Use `get_operator_status` from peers for operators without `rpc_url`.

## Notes

Every `[[bridge.operators]]` entry in config must now include `name`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 