### PR TITLE
ci(cd): push dashboard images to shared-services ECR; drop deployment job

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,16 +9,7 @@ on:
   #     - main
   #   types:
   #     - closed
-  workflow_dispatch:
-    inputs:
-      environment:
-        description: 'Select environment'
-        default: 'staging'
-        type: choice
-        options:
-          - staging
-          # currently we do not support cd to production, it's only for future reference
-          - production
+  workflow_dispatch: {}
 env:
   CI: false
   COMMIT: ${{ github.sha }}
@@ -31,7 +22,6 @@ jobs:
       id-token: write
     name: Build and Push Docker Images
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment || (github.ref == 'refs/heads/main' && 'staging') }}
     strategy:
       matrix:
         service: [frontend, backend]

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,7 +59,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY_PREFIX: ${{ vars.ECR_REPOSITORY_PREFIX }}
         run: |
-          IMAGE_TAG=${COMMIT::7}
+          IMAGE_TAG=${COMMIT}
           SERVICE="${{ matrix.service }}"
           # Flat, per-service repo in shared-services ECR, e.g.
           # strata/strata-dashboards-backend. ECR_REPOSITORY_PREFIX is the repo

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,6 +51,8 @@ jobs:
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2
         with:
           mask-password: "true"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v3
       - name: Build and push Docker image
         id: build-and-push
         env:
@@ -59,9 +61,6 @@ jobs:
         run: |
           IMAGE_TAG=${COMMIT::7}
           SERVICE="${{ matrix.service }}"
-
-          DOCKERFILE_PATH="$SERVICE.Dockerfile"
-          CONTEXT_DIR="."
           # Flat, per-service repo in shared-services ECR, e.g.
           # strata/strata-dashboards-backend. ECR_REPOSITORY_PREFIX is the repo
           # family (e.g. strata/strata-dashboards) and the service is appended
@@ -74,6 +73,9 @@ jobs:
           # Only the immutable commit tag is pushed. Shared-services repos are
           # created IMMUTABLE, so re-pushing a moving :latest tag would fail on
           # the second build; deployments values reference the SHA tag anyway.
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
-                      -f $DOCKERFILE_PATH $CONTEXT_DIR
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker buildx build \
+            --platform linux/amd64 \
+            --file "$SERVICE.Dockerfile" \
+            --tag "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" \
+            --push \
+            .

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,85 +59,21 @@ jobs:
         run: |
           IMAGE_TAG=${COMMIT::7}
           SERVICE="${{ matrix.service }}"
-          echo "Building and pushing $SERVICE image with tag $IMAGE_TAG and latest"
 
           DOCKERFILE_PATH="$SERVICE.Dockerfile"
           CONTEXT_DIR="."
-          ECR_REPOSITORY="$ECR_REPOSITORY_PREFIX/${SERVICE}"
+          # Flat, per-service repo in shared-services ECR, e.g.
+          # strata/strata-dashboards-backend. ECR_REPOSITORY_PREFIX is the repo
+          # family (e.g. strata/strata-dashboards) and the service is appended
+          # with a hyphen, matching the repo names the deployments values pull
+          # from.
+          ECR_REPOSITORY="${ECR_REPOSITORY_PREFIX}-${SERVICE}"
 
-          # Build with both the commit tag and latest
+          echo "Building and pushing $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+          # Only the immutable commit tag is pushed. Shared-services repos are
+          # created IMMUTABLE, so re-pushing a moving :latest tag would fail on
+          # the second build; deployments values reference the SHA tag anyway.
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
-                      -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
                       -f $DOCKERFILE_PATH $CONTEXT_DIR
-
-          # Push both tags
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
-  update-helm-values:
-    name: Update Helm Values
-    needs: [build-and-push]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    environment: ${{ inputs.environment || (github.ref == 'refs/heads/main' && 'staging') }}
-    steps:
-      - name: Set up SSH for private repo access
-        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # 0.10.0
-        with:
-          ssh-private-key: ${{ secrets.DEPLOYMENTS_REPO_WRITE }}
-      - name: Clone deployments repo (specific branch)
-        env:
-          BRANCH_OF_DEPLOYMENT_REPO: ${{ vars.BRANCH_OF_DEPLOYMENT_REPO }}
-        run: |
-          git clone --depth=1 --branch "$BRANCH_OF_DEPLOYMENT_REPO" git@github.com:alpenlabs/deployments.git deployments
-          cd deployments || exit 1
-          git checkout "$BRANCH_OF_DEPLOYMENT_REPO"
-
-      - name: Install yq
-        run: |
-          sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
-          sudo chmod +x /usr/local/bin/yq
-      - name: Debug yq Version
-        run: |
-          yq --version
-          which yq
-      - name: Update Docker image tag in Helm values # Sanitized SHORT_TAG and safe yq usage
-        env:
-          CLUSTER_NAME: ${{ vars.CLUSTER_NAME }}
-        run: |
-          # Sanitize and truncate SHORT_TAG
-          SHORT_TAG="${COMMIT//[^a-zA-Z0-9._-]/}"
-          SHORT_TAG="${SHORT_TAG:0:7}"
-
-          VALUES_FILE="deployments/clusters/$CLUSTER_NAME/values/strata-apps-values.yaml"
-
-
-          echo "Updating frontend tag in $VALUES_FILE"
-          yq eval -i ".strataStatus.frontend.image.tag = \"$SHORT_TAG\"" "$VALUES_FILE"
-
-          echo "Updating backend tag in $VALUES_FILE"
-          yq eval -i ".strataStatus.backend.image.tag = \"$SHORT_TAG\"" "$VALUES_FILE"
-
-
-      - name: Commit and push changes
-        env:
-          GH_ACTIONS_USER_NAME: ${{ vars.GH_ACTIONS_USER_NAME }}
-          CLUSTER_NAME: ${{ vars.CLUSTER_NAME }}
-          BRANCH_OF_DEPLOYMENT_REPO: ${{ vars.BRANCH_OF_DEPLOYMENT_REPO }}
-        run: |
-          SHORT_TAG="${COMMIT//[^a-zA-Z0-9._-]/}"
-          SHORT_TAG="${SHORT_TAG:0:7}"
-
-          cd deployments
-          git config user.name "$GH_ACTIONS_USER_NAME"
-          git config user.email "$GH_ACTIONS_USER_NAME@alpenlabs.io"
-
-          if git diff --quiet; then
-            echo "No changes to commit."
-          else
-            git add clusters/$CLUSTER_NAME/values
-            git commit -m "Update image tags to $SHORT_TAG for updated services"
-            git pull --rebase origin $BRANCH_OF_DEPLOYMENT_REPO
-            git push origin $BRANCH_OF_DEPLOYMENT_REPO
-          fi


### PR DESCRIPTION
## Problem (STR-3944)

The dashboards CI pushed images to the `tn1` registry (`888577024788`) with nested repo paths (`tn1/strata-dashboards/<service>`), while the deployments values pull from **shared-services** (`496607027995`) with flat repo names (`strata/strata-dashboards-<service>`). Every image bump therefore required a manual cross-account image mirror.

## Change (this PR — `cd.yml`, the status/`strata-dashboards` flavor)

- **Push to shared-services with flat repo names.** `ECR_REPOSITORY` is now `${ECR_REPOSITORY_PREFIX}-${SERVICE}`, producing `strata/strata-dashboards-<service>`, matching the repos the deployments values reference.
- **Drop the `:latest` push.** Shared-services repos are created with immutable tags, so re-pushing a moving `:latest` fails on the second build. Values reference the commit-SHA tag anyway.
- **Remove the values-bump / deployment job** (`update-helm-values`). This workflow now only publishes images; the deployment bump is handled elsewhere.


## Not covered here — the internal-dashboards flavor

`strata-internal-dashboards-*` is built by a **separate** workflow, `cd-internal.yml`, which currently lives on the unmerged `internal-dashboard` branch (not on `main`). It has the identical structure and needs the same fix in its own PR against that branch. The push role above is intentionally scoped to cover its two repos as well, so no second role is needed.

## Acceptance

- On push to `main`, `build-and-push` publishes `496607027995.dkr.ecr.us-east-1.amazonaws.com/strata/strata-dashboards-{backend,frontend}:<sha7>` and no `:latest`.
- No commit is made to the deployments repo by this workflow.
- Second consecutive build succeeds (no immutable-tag conflict).
