### PR TITLE
ci(cd-internal): push internal-dashboard images to shared-services ECR via buildx

### DIFF
--- a/.github/workflows/cd-internal.yml
+++ b/.github/workflows/cd-internal.yml
@@ -4,15 +4,7 @@ on:
   push:
     branches:
       - internal-dashboard
-  workflow_dispatch:
-    inputs:
-      environment:
-        description: 'Select environment'
-        default: 'staging'
-        type: choice
-        options:
-          - staging
-          - production
+  workflow_dispatch: {}
 
 env:
   CI: false
@@ -26,7 +18,6 @@ jobs:
       id-token: write
     name: Build and Push Docker Images (Internal)
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment || (github.ref == 'refs/heads/internal-dashboard' && 'staging') }}
     strategy:
       matrix:
         service: [frontend, backend]

--- a/.github/workflows/cd-internal.yml
+++ b/.github/workflows/cd-internal.yml
@@ -46,91 +46,31 @@ jobs:
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
         with:
           mask-password: "true"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v3
       - name: Build and push Docker image
         id: build-and-push
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY_PREFIX: ${{ vars.ECR_REPOSITORY_PREFIX_INTERNAL }}
         run: |
-          IMAGE_TAG=${COMMIT::7}
+          IMAGE_TAG=${COMMIT}
           SERVICE="${{ matrix.service }}"
-          echo "Building and pushing $SERVICE image with tag $IMAGE_TAG and latest for internal dashboard"
+          # Flat, per-service repo in shared-services ECR, e.g.
+          # strata/strata-internal-dashboards-backend. ECR_REPOSITORY_PREFIX_INTERNAL
+          # is the repo family (e.g. strata/strata-internal-dashboards) and the
+          # service is appended with a hyphen, matching the repo names the
+          # deployments values pull from.
+          ECR_REPOSITORY="${ECR_REPOSITORY_PREFIX}-${SERVICE}"
 
-          DOCKERFILE_PATH="$SERVICE.Dockerfile"
-          CONTEXT_DIR="."
-          ECR_REPOSITORY="$ECR_REPOSITORY_PREFIX/${SERVICE}"
+          echo "Building and pushing $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
-          # Build with both the commit tag and latest
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
-                      -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
-                      -f $DOCKERFILE_PATH $CONTEXT_DIR
-
-          # Push both tags
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
-  update-helm-values:
-    name: Update Helm Values (Internal)
-    needs: [build-and-push]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    environment: ${{ inputs.environment || (github.ref == 'refs/heads/internal-dashboard' && 'staging') }}
-    steps:
-      - name: Set up SSH for private repo access
-        uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # 0.9.1
-        with:
-          ssh-private-key: ${{ secrets.DEPLOYMENTS_REPO_WRITE }}
-      - name: Clone deployments repo (specific branch)
-        env:
-          BRANCH_OF_DEPLOYMENT_REPO: ${{ vars.BRANCH_OF_DEPLOYMENT_REPO }}
-        run: |
-          git clone --depth=1 --branch "$BRANCH_OF_DEPLOYMENT_REPO" git@github.com:alpenlabs/deployments.git deployments
-          cd deployments || exit 1
-          git checkout "$BRANCH_OF_DEPLOYMENT_REPO"
-
-      - name: Install yq
-        run: |
-          sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
-          sudo chmod +x /usr/local/bin/yq
-      - name: Debug yq Version
-        run: |
-          yq --version
-          which yq
-      - name: Update Docker image tag in Helm values (Internal)
-        env:
-          CLUSTER_NAME: ${{ vars.CLUSTER_NAME }}
-        run: |
-          # Sanitize and truncate SHORT_TAG
-          SHORT_TAG="${COMMIT//[^a-zA-Z0-9._-]/}"
-          SHORT_TAG="${SHORT_TAG:0:7}"
-
-          VALUES_FILE="deployments/clusters/$CLUSTER_NAME/values/strata-apps-values.yaml"
-
-          echo "Updating frontend tag in $VALUES_FILE for strataDashboard (internal dashboard)"
-          yq eval -i ".strataDashboard.frontend.image.tag = \"$SHORT_TAG\"" "$VALUES_FILE"
-
-          echo "Updating backend tag in $VALUES_FILE for strataDashboard (internal dashboard)"
-          yq eval -i ".strataDashboard.backend.image.tag = \"$SHORT_TAG\"" "$VALUES_FILE"
-
-      - name: Commit and push changes
-        env:
-          GH_ACTIONS_USER_NAME: ${{ vars.GH_ACTIONS_USER_NAME }}
-          CLUSTER_NAME: ${{ vars.CLUSTER_NAME }}
-          BRANCH_OF_DEPLOYMENT_REPO: ${{ vars.BRANCH_OF_DEPLOYMENT_REPO }}
-        run: |
-          SHORT_TAG="${COMMIT//[^a-zA-Z0-9._-]/}"
-          SHORT_TAG="${SHORT_TAG:0:7}"
-
-          cd deployments
-          git config user.name "$GH_ACTIONS_USER_NAME"
-          git config user.email "$GH_ACTIONS_USER_NAME@alpenlabs.io"
-
-          if git diff --quiet; then
-            echo "No changes to commit."
-          else
-            git add clusters/$CLUSTER_NAME/values
-            git commit -m "Update internal dashboard image tags to $SHORT_TAG"
-            git pull --rebase origin $BRANCH_OF_DEPLOYMENT_REPO
-            git push origin $BRANCH_OF_DEPLOYMENT_REPO
-          fi
+          # Only the immutable commit tag is pushed. Shared-services repos are
+          # created IMMUTABLE, so re-pushing a moving :latest tag would fail on
+          # the second build; deployments values reference the SHA tag anyway.
+          docker buildx build \
+            --platform linux/amd64 \
+            --file "$SERVICE.Dockerfile" \
+            --tag "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" \
+            --push \
+            .


### PR DESCRIPTION
## Problem (STR-3944, internal-dashboards flavor)

Companion to alpen-dashboards#289 (which fixes `cd.yml` / the status flavor). This workflow builds the `strata-internal-dashboards-*` images and had the same registry split: it pushed to `tn1` with nested paths while deployments values pull from shared-services (`496607027995`) with flat repo names — forcing a manual mirror on every bump.

> Base is `internal-dashboard` (not `main`) because that is where `cd-internal.yml` currently lives.

## Change

- **Push to shared-services with flat repo names** via `${ECR_REPOSITORY_PREFIX_INTERNAL}-${SERVICE}`, producing `strata/strata-internal-dashboards-<service>`.
- **`docker buildx build --push`** with a `docker/setup-buildx-action` step, matching `alpen` / `bitcoin_signet`.
- **Full commit SHA** as the image tag (`IMAGE_TAG=${COMMIT}`).
- **Drop the `:latest` push** — shared-services repos are immutable; a moving `:latest` fails on the second build.
- **Remove the values-bump / deployment job.** Image publishing only.
- `workflow_dispatch` retained, so the build can be triggered manually.

## Required before merge (same as #289)

1. **Shared-services push role** `github-actions-dashboards-push` (alpen-infra) — scoped to include `strata/strata-internal-dashboards-{backend,frontend}`. One role covers both flavors.
2. **`secrets.AWS_ECR_ROLE`** repointed to that role.
3. **`vars.ECR_REPOSITORY_PREFIX_INTERNAL`**: `tn1/strata-internal-dashboards` -> `strata/strata-internal-dashboards`.
4. Optional cleanup of the now-unused deploy secrets/vars.

## Acceptance

- On push to `internal-dashboard` (or manual dispatch), publishes `496607027995.dkr.ecr.us-east-1.amazonaws.com/strata/strata-internal-dashboards-{backend,frontend}:<full-sha>`, no `:latest`.
- No commit made to the deployments repo by this workflow.
- Second consecutive build succeeds (no immutable-tag conflict).
