### PR TITLE
chore(cd): rename workflow "Kubernetes CI/CD" -> "Build & Push Dashboard Images"

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: Kubernetes CI/CD
+name: Build & Push Dashboard Images
 
 on:
   push:


### PR DESCRIPTION
The `cd.yml` workflow was displayed as **Kubernetes CI/CD**, which is now misleading on both counts: it touches no Kubernetes, and it no longer does CD — the values-bump/deploy job was removed (STR-3944), leaving only Docker image build + push to ECR.

Renames the workflow display name to **Build & Push Dashboard Images** to match what it does (and to parallel the internal-dashboard workflow).

- Display `name:` only — job names, triggers, and permissions are unchanged, so no branch-protection required-check names change.
- This workflow isn't a PR check (it runs on push to `main`), so no PR-gating impact.

Follow-ups (not in this PR): `cd-internal.yml` is still "Internal Dashboard CI/CD" (the "CD" is likewise inaccurate) — a matching rename can go on the `internal-dashboard` branch. Renaming the files themselves (`cd.yml` implies CD) is a larger change touching CODEOWNERS and is left out deliberately.