### PR TITLE
feat(network)!: implement new network page requirements

### DIFF
--- a/backend/crates/config/src/lib.rs
+++ b/backend/crates/config/src/lib.rs
@@ -52,6 +52,9 @@ const DEFAULT_RETRY_POLICY_BASE: f64 = 1.5;
 /// Default timeout for Esplora HTTP requests in seconds.
 const DEFAULT_ESPLORA_REQUEST_TIMEOUT_S: u64 = 5;
 
+/// Default timeout for bundler health check requests in seconds.
+const DEFAULT_BUNDLER_REQUEST_TIMEOUT_S: u64 = 5;
+
 /// Default time a network status request waits for the first poll result.
 const DEFAULT_NETWORK_INITIAL_STATUS_WAIT_TIMEOUT_S: u64 = 5;
 
@@ -63,6 +66,9 @@ const DEFAULT_WITHDRAWAL_PAIRING_BATCH_SIZE: usize = 1_000;
 
 fn default_esplora_request_timeout_s() -> u64 {
     DEFAULT_ESPLORA_REQUEST_TIMEOUT_S
+}
+fn default_bundler_request_timeout_s() -> u64 {
+    DEFAULT_BUNDLER_REQUEST_TIMEOUT_S
 }
 fn default_network_initial_status_wait_timeout_s() -> u64 {
     DEFAULT_NETWORK_INITIAL_STATUS_WAIT_TIMEOUT_S
@@ -77,14 +83,24 @@ fn default_withdrawal_pairing_batch_size() -> usize {
 /// Configuration for network monitoring services
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct NetworkMonitoringConfig {
-    /// JSON-RPC Endpoint for Strata sequencer
-    sequencer_url: String,
+    /// JSON-RPC endpoint for the Alpen sequencer
+    alpen_sequencer_url: String,
 
-    /// JSON-RPC Endpoint for Strata client and reth
-    rpc_url: String,
+    /// Public JSON-RPC endpoint for Alpen
+    alpen_rpc_url: String,
+
+    /// JSON-RPC endpoint for the Strata sequencer
+    strata_sequencer_url: String,
+
+    /// Public JSON-RPC endpoint for Strata
+    strata_rpc_url: String,
 
     /// Bundler health check URL
     bundler_url: String,
+
+    /// Timeout for bundler health check requests in seconds.
+    #[serde(default = "default_bundler_request_timeout_s")]
+    bundler_request_timeout_s: u64,
 
     /// Max retries for status queries
     retry_policy_max_retries: u64,
@@ -101,16 +117,28 @@ pub struct NetworkMonitoringConfig {
 }
 
 impl NetworkMonitoringConfig {
-    pub fn sequencer_url(&self) -> &str {
-        &self.sequencer_url
+    pub fn alpen_sequencer_url(&self) -> &str {
+        &self.alpen_sequencer_url
     }
 
-    pub fn rpc_url(&self) -> &str {
-        &self.rpc_url
+    pub fn alpen_rpc_url(&self) -> &str {
+        &self.alpen_rpc_url
+    }
+
+    pub fn strata_sequencer_url(&self) -> &str {
+        &self.strata_sequencer_url
+    }
+
+    pub fn strata_rpc_url(&self) -> &str {
+        &self.strata_rpc_url
     }
 
     pub fn bundler_url(&self) -> &str {
         &self.bundler_url
+    }
+
+    pub fn bundler_request_timeout_s(&self) -> u64 {
+        self.bundler_request_timeout_s
     }
 
     pub fn status_refetch_interval(&self) -> u64 {
@@ -121,17 +149,8 @@ impl NetworkMonitoringConfig {
         self.initial_status_wait_timeout_s
     }
 
-    /// Retry policy for sequencer status queries
-    pub fn sequencer_retry_policy(&self) -> ExponentialBackoff {
-        ExponentialBackoff::new(
-            self.retry_policy_max_retries,
-            self.retry_policy_total_time_s,
-            DEFAULT_RETRY_POLICY_BASE,
-        )
-    }
-
-    /// Retry policy for RPC endpoint status queries
-    pub fn rpc_retry_policy(&self) -> ExponentialBackoff {
+    /// Retry policy for status queries
+    pub fn retry_policy(&self) -> ExponentialBackoff {
         ExponentialBackoff::new(
             self.retry_policy_max_retries,
             self.retry_policy_total_time_s,
@@ -378,8 +397,10 @@ host = "0.0.0.0"
 port = 3000
 
 [network]
-sequencer_url = "https://strata.testnet.alpenlabs.io"
-rpc_url = "https://alpen.testnet.alpenlabs.io"
+alpen_sequencer_url = "https://alpen.testnet.alpenlabs.io"
+alpen_rpc_url = "https://alpen.testnet.alpenlabs.io"
+strata_sequencer_url = "https://strata.testnet.alpenlabs.io"
+strata_rpc_url = "https://strata.testnet.alpenlabs.io"
 bundler_url = "https://bundler.testnet.alpenlabs.io/health"
 retry_policy_max_retries = 5
 retry_policy_total_time_s = 60
@@ -445,8 +466,10 @@ host = "127.0.0.1"
 port = 8080
 
 [network]
-sequencer_url = ""
-rpc_url = ""
+alpen_sequencer_url = ""
+alpen_rpc_url = ""
+strata_sequencer_url = ""
+strata_rpc_url = ""
 bundler_url = ""
 retry_policy_max_retries = 0
 retry_policy_total_time_s = 0
@@ -491,8 +514,10 @@ host = "127.0.0.1"
 port = 8080
 
 [network]
-sequencer_url = "https://sequencer.example.com"
-rpc_url = "https://rpc.example.com"
+alpen_sequencer_url = "https://alpen-sequencer.example.com"
+alpen_rpc_url = "https://alpen-rpc.example.com"
+strata_sequencer_url = "https://strata-sequencer.example.com"
+strata_rpc_url = "https://strata-rpc.example.com"
 bundler_url = "https://bundler.example.com/health"
 retry_policy_max_retries = 3
 retry_policy_total_time_s = 30
@@ -534,8 +559,20 @@ withdrawal_denomination_sats = 100000000
         assert_eq!(config.server.host(), "127.0.0.1");
         assert_eq!(config.server.port(), 8080);
         assert_eq!(
-            config.network.sequencer_url(),
-            "https://sequencer.example.com"
+            config.network.alpen_sequencer_url(),
+            "https://alpen-sequencer.example.com"
+        );
+        assert_eq!(
+            config.network.alpen_rpc_url(),
+            "https://alpen-rpc.example.com"
+        );
+        assert_eq!(
+            config.network.strata_sequencer_url(),
+            "https://strata-sequencer.example.com"
+        );
+        assert_eq!(
+            config.network.strata_rpc_url(),
+            "https://strata-rpc.example.com"
         );
         assert_eq!(config.network.status_refetch_interval(), 5);
         assert_eq!(config.network.initial_status_wait_timeout_s(), 4);
@@ -588,8 +625,10 @@ host = "127.0.0.1"
 port = 8080
 
 [network]
-sequencer_url = ""
-rpc_url = ""
+alpen_sequencer_url = ""
+alpen_rpc_url = ""
+strata_sequencer_url = ""
+strata_rpc_url = ""
 bundler_url = ""
 retry_policy_max_retries = 0
 retry_policy_total_time_s = 0
@@ -625,8 +664,10 @@ host = "127.0.0.1"
 port = 8080
 
 [network]
-sequencer_url = ""
-rpc_url = ""
+alpen_sequencer_url = ""
+alpen_rpc_url = ""
+strata_sequencer_url = ""
+strata_rpc_url = ""
 bundler_url = ""
 retry_policy_max_retries = 0
 retry_policy_total_time_s = 0
@@ -659,8 +700,10 @@ host = "127.0.0.1"
 port = 8080
 
 [network]
-sequencer_url = ""
-rpc_url = ""
+alpen_sequencer_url = ""
+alpen_rpc_url = ""
+strata_sequencer_url = ""
+strata_rpc_url = ""
 bundler_url = ""
 retry_policy_max_retries = 0
 retry_policy_total_time_s = 0

--- a/backend/crates/network/src/status.rs
+++ b/backend/crates/network/src/status.rs
@@ -70,7 +70,7 @@ async fn call_json_rpc_status(
 }
 
 /// Calls the OL `strata_getChainStatus` method.
-async fn call_sequencer_status(client: &HttpClient, retry_policy: ExponentialBackoff) -> Status {
+async fn call_chain_status(client: &HttpClient, retry_policy: ExponentialBackoff) -> Status {
     call_json_rpc_status(
         client,
         STRATA_CHAIN_STATUS_METHOD,
@@ -81,7 +81,7 @@ async fn call_sequencer_status(client: &HttpClient, retry_policy: ExponentialBac
 }
 
 /// Calls the EVM `eth_blockNumber` method.
-async fn call_rpc_endpoint_status(client: &HttpClient, retry_policy: ExponentialBackoff) -> Status {
+async fn call_eth_block_number(client: &HttpClient, retry_policy: ExponentialBackoff) -> Status {
     call_json_rpc_status(
         client,
         ETH_BLOCK_NUMBER_METHOD,
@@ -106,6 +106,56 @@ async fn check_bundler_health(
     Status::Offline
 }
 
+/// Clients for the monitored network endpoints, built once per monitoring task.
+struct NetworkClients {
+    alpen_sequencer: HttpClient,
+    alpen_rpc: HttpClient,
+    strata_sequencer: HttpClient,
+    strata_rpc: HttpClient,
+    bundler: reqwest::Client,
+}
+
+impl NetworkClients {
+    fn new(config: &NetworkMonitoringConfig) -> Self {
+        Self {
+            alpen_sequencer: create_rpc_client(config.alpen_sequencer_url()),
+            alpen_rpc: create_rpc_client(config.alpen_rpc_url()),
+            strata_sequencer: create_rpc_client(config.strata_sequencer_url()),
+            strata_rpc: create_rpc_client(config.strata_rpc_url()),
+            // `reqwest` applies no timeout by default, and a poll only completes
+            // once every check has, so an unbounded request would stall the
+            // whole monitoring loop.
+            bundler: reqwest::Client::builder()
+                .timeout(Duration::from_secs(config.bundler_request_timeout_s()))
+                .build()
+                .expect("failed to build bundler HTTP client"),
+        }
+    }
+}
+
+/// Queries every monitored endpoint once, concurrently, returning when all
+/// checks have finished.
+async fn poll_network_status(
+    clients: &NetworkClients,
+    config: &NetworkMonitoringConfig,
+) -> NetworkStatus {
+    let (alpen_sequencer, alpen_rpc, strata_sequencer, strata_rpc, alpen_bundler) = tokio::join!(
+        call_eth_block_number(&clients.alpen_sequencer, config.retry_policy()),
+        call_eth_block_number(&clients.alpen_rpc, config.retry_policy()),
+        call_chain_status(&clients.strata_sequencer, config.retry_policy()),
+        call_chain_status(&clients.strata_rpc, config.retry_policy()),
+        check_bundler_health(&clients.bundler, config),
+    );
+
+    NetworkStatus {
+        alpen_sequencer,
+        alpen_rpc,
+        alpen_bundler,
+        strata_sequencer,
+        strata_rpc,
+    }
+}
+
 /// Periodically polls configured network service endpoints and updates status state.
 pub async fn network_monitoring_task(
     context: Arc<NetworkMonitoringContext>,
@@ -115,9 +165,7 @@ pub async fn network_monitoring_task(
     let mut interval = interval(Duration::from_secs(
         context.config().status_refetch_interval(),
     ));
-    let sequencer_client = create_rpc_client(context.config().sequencer_url());
-    let rpc_client = create_rpc_client(context.config().rpc_url());
-    let http_client = reqwest::Client::new();
+    let clients = NetworkClients::new(context.config());
 
     loop {
         tokio::select! {
@@ -125,14 +173,7 @@ pub async fn network_monitoring_task(
             _ = interval.tick() => {}
         }
 
-        let sequencer =
-            call_sequencer_status(&sequencer_client, context.config().sequencer_retry_policy())
-                .await;
-        let rpc_endpoint =
-            call_rpc_endpoint_status(&rpc_client, context.config().rpc_retry_policy()).await;
-        let bundler_endpoint = check_bundler_health(&http_client, context.config()).await;
-
-        let new_status = NetworkStatus::new(sequencer, rpc_endpoint, bundler_endpoint);
+        let new_status = poll_network_status(&clients, context.config()).await;
 
         info!(?new_status, "updated network status");
 

--- a/backend/crates/network/src/types.rs
+++ b/backend/crates/network/src/types.rs
@@ -14,27 +14,21 @@ pub(crate) enum Status {
 
 #[derive(Serialize, Clone, Debug)]
 pub struct NetworkStatus {
-    sequencer: Status,
-    rpc_endpoint: Status,
-    bundler_endpoint: Status,
+    pub(crate) alpen_sequencer: Status,
+    pub(crate) alpen_rpc: Status,
+    pub(crate) alpen_bundler: Status,
+    pub(crate) strata_sequencer: Status,
+    pub(crate) strata_rpc: Status,
 }
 
 impl Default for NetworkStatus {
     fn default() -> Self {
         Self {
-            sequencer: Status::Offline,
-            rpc_endpoint: Status::Offline,
-            bundler_endpoint: Status::Offline,
-        }
-    }
-}
-
-impl NetworkStatus {
-    pub(crate) fn new(sequencer: Status, rpc_endpoint: Status, bundler_endpoint: Status) -> Self {
-        Self {
-            sequencer,
-            rpc_endpoint,
-            bundler_endpoint,
+            alpen_sequencer: Status::Offline,
+            alpen_rpc: Status::Offline,
+            alpen_bundler: Status::Offline,
+            strata_sequencer: Status::Offline,
+            strata_rpc: Status::Offline,
         }
     }
 }
@@ -108,8 +102,10 @@ mod tests {
     fn test_config() -> NetworkMonitoringConfig {
         toml::from_str(
             r#"
-            sequencer_url = "http://localhost:8545"
-            rpc_url = "http://localhost:8546"
+            alpen_sequencer_url = "http://localhost:8545"
+            alpen_rpc_url = "http://localhost:8546"
+            strata_sequencer_url = "http://localhost:8432"
+            strata_rpc_url = "http://localhost:8433"
             bundler_url = "http://localhost:3000/health"
             retry_policy_max_retries = 1
             retry_policy_total_time_s = 1

--- a/backend/example-config.toml
+++ b/backend/example-config.toml
@@ -8,48 +8,54 @@ datadir = "data"
 
 # Network monitoring configuration
 [network]
-  bundler_url                   = "https://bundler-staging.testnet-v2.alpenlabs.io/health"
+  alpen_rpc_url                 = "https://alpen.testnet.alpen.org"
+  alpen_sequencer_url           = "http://localhost:56917/"
+  bundler_url                   = "https://bundler.testnet.alpen.org/health"
   initial_status_wait_timeout_s = 30
   retry_policy_max_retries      = 5
   retry_policy_total_time_s     = 60
-  rpc_url                       = "https://alpen-staging.testnet-v2.alpenlabs.io"
-  sequencer_url                 = "https://strata-staging.testnet-v2.alpenlabs.io"
   status_refetch_interval_s     = 10
+  strata_rpc_url                = "https://strata.testnet.alpen.org"
+  strata_sequencer_url          = "http://localhost:56790/"
 
 # Bridge monitoring configuration
 [bridge]
   esplora_request_timeout_s     = 5
-  esplora_url                   = "https://esplora-staging.testnet-v2.alpenlabs.io"
+  esplora_url                   = "https://esplora.testnet-prod.alpenlabs.io"
   initial_status_wait_timeout_s = 5
-  max_tx_confirmations          = 6
+  max_tx_confirmations          = 18
   status_refetch_interval_s     = 120
   withdrawal_pairing_batch_size = 1_000
 
   # Bridge operators configuration
   [[bridge.operators]]
     name       = "Alpen Labs #1"
-    public_key = "02157d08fa2eb6071cef0750bcf1c0c9e94c2f05f629cdbdb3982851dce9472cd0"
-    rpc_url    = "http://localhost:54195"
+    public_key = "025a46d9052f64ad8f3a6ad65342ddead4f4f76f92ac184868ca402b8bed627cb8"
+    rpc_url    = "http://localhost:55936"
 
   [[bridge.operators]]
     name       = "Alpen Labs #2"
     public_key = "02444d7dca618168c1c4963a1556c2cab7d9172f0702cc3498dff72015717c0968"
-    rpc_url    = "http://localhost:54367"
+    rpc_url    = "http://localhost:56062"
 
   [[bridge.operators]]
     name       = "Alpen Labs #3"
     public_key = "02bff82939acd1deaeed90d6620b64ec475c6ff80a30fd07fca05315ddb1df873d"
-    rpc_url    = "http://localhost:54492"
+    rpc_url    = "http://localhost:56135"
 
   [[bridge.operators]]
-    name       = "External Operator #1"
+    name       = "Stakely"
     public_key = "02a96ec5406c02be9b6a7b254af44acf15b23b908b21619f9be583d82f943b6fb2"
+
+  [[bridge.operators]]
+    name       = "Chainflow"
+    public_key = "024fba11d351c5e3b988a938b82bf210c1e7736594f6924f8e8ebe0c462e03569b"
 
 # Withdrawal-intent indexer configuration
 [withdrawal_indexer]
   batch_size                   = 1_000
-  eth_rpc_url                  = "https://alpen-staging.testnet-v2.alpenlabs.io"
+  eth_rpc_url                  = "https://alpen.testnet.alpen.org"
   finality_lag                 = 12
   poll_interval_s              = 10
   start_block                  = 0
-  withdrawal_denomination_sats = 100_000_000
+  withdrawal_denomination_sats = 200_000_000

--- a/frontend/src/components/StatusCard.tsx
+++ b/frontend/src/components/StatusCard.tsx
@@ -4,13 +4,13 @@ interface StatusCardProps {
 }
 
 const StatusCard = ({ title, status }: StatusCardProps) => {
+  const label = status.charAt(0).toUpperCase() + status.slice(1).toLowerCase();
+
   return (
     <div className="status-section">
-      <div className="status-title">{title.toUpperCase()}</div>
+      <div className="status-title">{title}</div>
       <div className="status-value">
-        <span className={`status-text ${status.toLowerCase()}`}>
-          {status.toUpperCase()}
-        </span>
+        <span className={`status-text ${status.toLowerCase()}`}>{label}</span>
       </div>
     </div>
   );

--- a/frontend/src/hooks/useNetworkStatus.ts
+++ b/frontend/src/hooks/useNetworkStatus.ts
@@ -2,9 +2,11 @@ import { useQuery } from '@tanstack/react-query';
 import { useConfig } from './useConfig';
 
 export type NetworkStatus = {
-  sequencer: string;
-  rpc_endpoint: string;
-  bundler_endpoint: string;
+  alpen_sequencer: string;
+  alpen_rpc: string;
+  alpen_bundler: string;
+  strata_sequencer: string;
+  strata_rpc: string;
 };
 
 const fetchNetworkStatus = async (baseUrl: string): Promise<NetworkStatus> => {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -94,20 +94,32 @@ export default function Dashboard() {
               {isLoading ? (
                 <p className="loading-text">Loading...</p>
               ) : (
-                <div className="status-cards">
-                  <StatusCard
-                    title="Sequencer status"
-                    status={data?.sequencer.toUpperCase() ?? 'Unknown'}
-                  />
-                  <StatusCard
-                    title="RPC endpoint status"
-                    status={data?.rpc_endpoint.toUpperCase() ?? 'Unknown'}
-                  />
-                  <StatusCard
-                    title="Bundler endpoint status"
-                    status={data?.bundler_endpoint.toUpperCase() ?? 'Unknown'}
-                  />
-                </div>
+                <>
+                  <div className="status-cards">
+                    <StatusCard
+                      title="Alpen sequencer"
+                      status={data?.alpen_sequencer.toUpperCase() ?? 'Unknown'}
+                    />
+                    <StatusCard
+                      title="Alpen RPC"
+                      status={data?.alpen_rpc.toUpperCase() ?? 'Unknown'}
+                    />
+                    <StatusCard
+                      title="Alpen bundler"
+                      status={data?.alpen_bundler.toUpperCase() ?? 'Unknown'}
+                    />
+                  </div>
+                  <div className="status-cards status-cards-centered">
+                    <StatusCard
+                      title="Strata sequencer"
+                      status={data?.strata_sequencer.toUpperCase() ?? 'Unknown'}
+                    />
+                    <StatusCard
+                      title="Strata RPC"
+                      status={data?.strata_rpc.toUpperCase() ?? 'Unknown'}
+                    />
+                  </div>
+                </>
               )}
             </Suspense>
           </div>

--- a/frontend/src/styles/network.css
+++ b/frontend/src/styles/network.css
@@ -5,11 +5,23 @@
   gap: 8px;
 }
 
+/* Second row holds fewer cards than the first; centre it under them. */
+.status-cards-centered {
+  justify-content: center;
+}
+
+.status-cards + .status-cards {
+  margin-top: 3rem;
+}
+
 .status-section {
   justify-content: space-between;
   margin: 0 10px;
   padding: 10px 10px;
-  width: 33%;
+  /* Fixed three-up basis (100% less 3x20px margins and 2x8px gaps) so the
+     second row's cards match the first row's width instead of stretching. */
+  flex: 0 0 calc((100% - 76px) / 3);
+  box-sizing: border-box;
   text-align: left;
 }
 
@@ -18,14 +30,16 @@
   margin: 0 1rem;
   color: black;
   font-weight: 600;
+  text-align: center;
 }
 
 .status-value {
-  padding: 2rem 10px;
+  padding: 2.75rem 10px;
+  max-width: 240px;
   margin: 0.5rem auto;
   border: 0.5px solid rgba(113, 128, 150, 1);
   box-shadow: 0px 4px 11px 0px rgba(0, 0, 0, 0.08);
-  border-radius: 10px;
+  border-radius: 20px;
   font-weight: bold;
   color: black;
   text-align: center;


### PR DESCRIPTION
## Description

Updates the Network dashboard to match the new wireframe by showing five status cards:
- Alpen sequencer
- Alpen RPC
- Alpen bundler
- Strata sequencer
- Strata RPC

Backend network monitoring now polls the Alpen and Strata endpoints separately and returns the expanded status response shape.

BREAKING CHANGE: `[network].sequencer_url` and `[network].rpc_url` are replaced by `alpen_sequencer_url`, `alpen_rpc_url`, `strata_sequencer_url` and `strata_rpc_url`.


Addresses [STR-3984](https://alpenlabs.atlassian.net/browse/STR-3984).

Created with help from Claude.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 

[STR-3984]: https://alpenlabs.atlassian.net/browse/STR-3984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ